### PR TITLE
tflint: Sending expression nodes as a text representation

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -5,8 +5,6 @@ import (
 	"net/rpc"
 
 	plugin "github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
@@ -36,28 +34,4 @@ func (RuleSetPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, er
 // the type of the related structure is registered in gob at the initial time.
 func init() {
 	gob.Register(tflint.Error{})
-	// https://github.com/hashicorp/hcl/blob/v2.0.0/hclsyntax/expression.go
-	gob.Register(&hclsyntax.LiteralValueExpr{})
-	gob.Register(&hclsyntax.ScopeTraversalExpr{})
-	gob.Register(&hclsyntax.RelativeTraversalExpr{})
-	gob.Register(&hclsyntax.FunctionCallExpr{})
-	gob.Register(&hclsyntax.ConditionalExpr{})
-	gob.Register(&hclsyntax.IndexExpr{})
-	gob.Register(&hclsyntax.TupleConsExpr{})
-	gob.Register(&hclsyntax.ObjectConsExpr{})
-	gob.Register(&hclsyntax.ObjectConsKeyExpr{})
-	gob.Register(&hclsyntax.ForExpr{})
-	gob.Register(&hclsyntax.SplatExpr{})
-	// https://github.com/hashicorp/hcl/blob/v2.0.0/hclsyntax/expression_ops.go
-	gob.Register(&hclsyntax.BinaryOpExpr{})
-	gob.Register(&hclsyntax.UnaryOpExpr{})
-	// https://github.com/hashicorp/hcl/blob/v2.0.0/hclsyntax/expression_template.go
-	gob.Register(&hclsyntax.TemplateExpr{})
-	gob.Register(&hclsyntax.TemplateJoinExpr{})
-	gob.Register(&hclsyntax.TemplateWrapExpr{})
-	// https://github.com/hashicorp/hcl/blob/v2.0.0/traversal.go
-	gob.Register(hcl.TraverseRoot{})
-	gob.Register(hcl.TraverseAttr{})
-	gob.Register(hcl.TraverseIndex{})
-	gob.Register(hcl.TraverseSplat{})
 }


### PR DESCRIPTION
See also https://github.com/hashicorp/hcl/issues/332

Currently, sending and receiving expression nodes via `gob` in the plugin system. However, this approach has two problems:

- Cannot support JSON syntax because `json.expression` is not exported
- Since it depends on the internal representation of the HCL package, changing this breaks plugin's compatibility.

After discussing this issue, I got the advice that it's best to use text representation for sending and receiving.

Following the advice, this PR changes that it sends and receives text instead of expression and it to be parsed as an expression by the plugin and host respectively.

Unfortunately, there is no expression-based JSON parsing API in HCL today. I'm opening a PR to add this function, but this pull request is pending until it is merged. See https://github.com/hashicorp/hcl/pull/381