### PR TITLE
tflint: Support meta-arguments for terraform.Resource

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -1,0 +1,331 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+func Test_WalkResourceAttributes(t *testing.T) {
+	src := `
+resource "aws_instance" "foo" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+resource "aws_s3_bucket" "bar" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+}`
+
+	runner := TestRunner(t, map[string]string{"main.tf": src})
+
+	walked := []*hcl.Attribute{}
+	walker := func(attribute *hcl.Attribute) error {
+		walked = append(walked, attribute)
+		return nil
+	}
+
+	if err := runner.WalkResourceAttributes("aws_instance", "instance_type", walker); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []*hcl.Attribute{
+		{
+			Name: "instance_type",
+			Expr: &hclsyntax.TemplateExpr{
+				Parts: []hclsyntax.Expression{
+					&hclsyntax.LiteralValueExpr{
+						SrcRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 4, Column: 20}, End: hcl.Pos{Line: 4, Column: 28}},
+					},
+				},
+				SrcRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 4, Column: 19}, End: hcl.Pos{Line: 4, Column: 29}},
+			},
+			Range:     hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 4, Column: 3}, End: hcl.Pos{Line: 4, Column: 29}},
+			NameRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 4, Column: 3}, End: hcl.Pos{Line: 4, Column: 16}},
+		},
+	}
+
+	opts := cmp.Options{
+		cmpopts.IgnoreFields(hclsyntax.LiteralValueExpr{}, "Val"),
+		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+	}
+	if !cmp.Equal(expected, walked, opts...) {
+		t.Fatalf("Diff: %s", cmp.Diff(expected, walked, opts...))
+	}
+}
+
+func Test_WalkResources(t *testing.T) {
+	src := `
+resource "aws_instance" "foo" {
+  provider = aws.west
+
+  count = 1
+  for_each = {
+    foo = "bar"
+  }
+
+  instance_type = "t2.micro"
+  
+  connection {
+    type = "ssh"
+  }
+
+  provisioner "local-exec" {
+    command    = "chmod 600 ssh-key.pem"
+    when       = destroy
+    on_failure = continue
+
+    connection {
+      type = "ssh"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+    ignore_changes        = all
+  }
+}
+
+resource "aws_s3_bucket" "bar" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+}`
+
+	runner := TestRunner(t, map[string]string{"main.tf": src})
+
+	walked := []*terraform.Resource{}
+	walker := func(resource *terraform.Resource) error {
+		walked = append(walked, resource)
+		return nil
+	}
+
+	if err := runner.WalkResources("aws_instance", walker); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []*terraform.Resource{
+		{
+			Mode: terraform.ManagedResourceMode,
+			Name: "foo",
+			Type: "aws_instance",
+			Config: parseBody(
+				t,
+				`provider = aws.west
+
+  count = 1
+  for_each = {
+    foo = "bar"
+  }
+
+  instance_type = "t2.micro"
+
+  connection {
+    type = "ssh"
+  }
+
+  provisioner "local-exec" {
+    command    = "chmod 600 ssh-key.pem"
+    when       = destroy
+    on_failure = continue
+
+    connection {
+      type = "ssh"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+    ignore_changes        = all
+  }`, "main.tf", 
+				hcl.Pos{Line: 3, Column: 3}, 
+				hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2, Column: 31}, End: hcl.Pos{Line: 31, Column: 2}},
+				hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 31, Column: 2}, End: hcl.Pos{Line: 31, Column: 2}},
+			),
+			Count:   parseExpression(t, `1`, "main.tf", hcl.Pos{Line: 5, Column: 11}),
+			ForEach: parseExpression(t, `{
+    foo = "bar"
+  }`, "main.tf", hcl.Pos{Line: 6, Column: 14}),
+
+			ProviderConfigRef: &terraform.ProviderConfigRef{
+				Name:       "aws",
+				NameRange:  hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 14}, End: hcl.Pos{Line: 3, Column: 17}},
+				Alias:      "west",
+				AliasRange: &hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 17}, End: hcl.Pos{Line: 3, Column: 22}},
+			},
+
+			Managed: &terraform.ManagedResource{
+				Connection: &terraform.Connection{
+					Config: parseBody(
+						t, 
+						`type = "ssh"`,
+						"main.tf",
+						hcl.Pos{Line: 13, Column: 5},
+						hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 12, Column: 14}, End: hcl.Pos{Line: 14, Column: 4}},
+						hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 14, Column: 4}, End: hcl.Pos{Line: 14, Column: 4}},
+					),
+					DeclRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 12, Column: 3}, End: hcl.Pos{Line: 12, Column: 13}},
+				},
+				Provisioners: []*terraform.Provisioner{
+					{
+						Type:       "local-exec",
+						Config: parseBody(
+							t, 
+							`command    = "chmod 600 ssh-key.pem"
+    when       = destroy
+    on_failure = continue
+
+    connection {
+      type = "ssh"
+    }`,
+							"main.tf",
+							hcl.Pos{Line: 17, Column: 5},
+							hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 16, Column: 28}, End: hcl.Pos{Line: 24, Column: 4}},
+							hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 24, Column: 4}, End: hcl.Pos{Line: 24, Column: 4}},
+						),
+						Connection: &terraform.Connection{
+							Config: parseBody(
+								t, 
+								`type = "ssh"`,
+								"main.tf",
+								hcl.Pos{Line: 22, Column: 7},
+								hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 21, Column: 16}, End: hcl.Pos{Line: 23, Column: 6}},
+								hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 23, Column: 6}, End: hcl.Pos{Line: 23, Column: 6}},
+							),
+							DeclRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 21, Column: 5}, End: hcl.Pos{Line: 21, Column: 15}},
+						},
+						When:       terraform.ProvisionerWhenDestroy,
+						OnFailure:  terraform.ProvisionerOnFailureContinue,
+						DeclRange:  hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 16, Column: 3}, End: hcl.Pos{Line: 16, Column: 27}},
+						TypeRange:  hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 16, Column: 15}, End: hcl.Pos{Line: 16, Column: 27}},
+					},
+				},
+
+				CreateBeforeDestroy:    true,
+				PreventDestroy:         true,
+				IgnoreAllChanges:       true,
+				CreateBeforeDestroySet: true,
+				PreventDestroySet:      true,
+			},
+			DeclRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2, Column: 1}, End: hcl.Pos{Line: 2, Column: 30}},
+			TypeRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2, Column: 10}, End: hcl.Pos{Line: 2, Column: 24}},
+		},
+	}
+
+	opts := cmp.Options{
+		cmpopts.IgnoreFields(hclsyntax.LiteralValueExpr{}, "Val"),
+		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+		cmpopts.IgnoreUnexported(hcl.TraverseRoot{}, hcl.TraverseAttr{}, hclsyntax.Body{}),
+	}
+	if !cmp.Equal(expected, walked, opts...) {
+		t.Fatalf("Diff: %s", cmp.Diff(expected, walked, opts...))
+	}
+}
+
+func parseBody(t *testing.T, src string, filename string, pos hcl.Pos, srcRange hcl.Range, endRange hcl.Range) hcl.Body {
+	file, diags := hclsyntax.ParseConfig([]byte(src), filename, pos)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	body := file.Body.(*hclsyntax.Body)
+	body.SrcRange = srcRange
+	body.EndRange = endRange
+
+	return body
+}
+
+func parseExpression(t *testing.T, src string, filename string, pos hcl.Pos) hcl.Expression {
+	expr, diags := hclsyntax.ParseExpression([]byte(src), filename, pos)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	return expr
+}
+
+func Test_EvaluateExpr(t *testing.T) {
+	src := `
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}`
+
+	runner := TestRunner(t, map[string]string{"main.tf": src})
+
+	err := runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
+		var instanceType string
+		if err := runner.EvaluateExpr(attribute.Expr, &instanceType); err != nil {
+			t.Fatal(err)
+		}
+
+		if instanceType != "t2.micro" {
+			t.Fatalf(`expected value is "t2.micro", but got "%s"`, instanceType)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type dummyRule struct{}
+
+func (r *dummyRule) Name() string              { return "dummy_rule" }
+func (r *dummyRule) Enabled() bool             { return true }
+func (r *dummyRule) Severity() string          { return tflint.ERROR }
+func (r *dummyRule) Link() string              { return "" }
+func (r *dummyRule) Check(tflint.Runner) error { return nil }
+
+func Test_EmitIssue(t *testing.T) {
+	src := `
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}`
+
+	runner := TestRunner(t, map[string]string{"main.tf": src})
+
+	err := runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
+		if err := runner.EmitIssue(&dummyRule{}, "issue found", attribute.Expr.Range(), tflint.Metadata{}); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := Issues{
+		{
+			Rule:    &dummyRule{},
+			Message: "issue found",
+			Range:   hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 19}, End: hcl.Pos{Line: 3, Column: 29}},
+		},
+	}
+
+	opt := cmpopts.IgnoreFields(hcl.Pos{}, "Byte")
+	if !cmp.Equal(expected, runner.Issues, opt) {
+		t.Fatalf("Diff: %s", cmp.Diff(expected, runner.Issues, opt))
+	}
+}
+
+func Test_EnsureNoError(t *testing.T) {
+	runner := TestRunner(t, map[string]string{})
+
+	var run bool
+	err := runner.EnsureNoError(nil, func() error {
+		run = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !run {
+		t.Fatal("Expected to exec the passed proc, but doesn't")
+	}
+}

--- a/terraform/addrs.go
+++ b/terraform/addrs.go
@@ -1,0 +1,14 @@
+package terraform
+
+// ResourceMode is an alternative representation of addrs.ResourceMode.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/addrs/resource.go#L253-L271
+type ResourceMode rune
+
+const (
+	// InvalidResourceMode is the zero value of ResourceMode.
+	InvalidResourceMode ResourceMode = 0
+	// ManagedResourceMode indicates a managed resource.
+	ManagedResourceMode ResourceMode = 'M'
+	// DataResourceMode indicates a data resource.
+	DataResourceMode ResourceMode = 'D'
+)

--- a/terraform/configs.go
+++ b/terraform/configs.go
@@ -1,0 +1,96 @@
+package terraform
+
+import "github.com/hashicorp/hcl/v2"
+
+// Resource is an alternative representation of configs.Resource.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/resource.go#L13-L33
+// DependsOn is not supported due to the difficulty of intermediate representation.
+type Resource struct {
+	Mode    ResourceMode
+	Name    string
+	Type    string
+	Config  hcl.Body
+	Count   hcl.Expression
+	ForEach hcl.Expression
+
+	ProviderConfigRef *ProviderConfigRef
+
+	// DependsOn []hcl.Traversal
+
+	Managed *ManagedResource
+
+	DeclRange hcl.Range
+	TypeRange hcl.Range
+}
+
+// ManagedResource is an alternative representation of configs.ManagedResource.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/resource.go#L35-L47
+// IgnoreChanges is not supported due to the difficulty of intermediate representation.
+type ManagedResource struct {
+	Connection   *Connection
+	Provisioners []*Provisioner
+
+	CreateBeforeDestroy bool
+	PreventDestroy      bool
+	// IgnoreChanges       []hcl.Traversal
+	IgnoreAllChanges bool
+
+	CreateBeforeDestroySet bool
+	PreventDestroySet      bool
+}
+
+// ProviderConfigRef is an alternative representation of configs.ProviderConfigRef.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/resource.go#L371-L376
+type ProviderConfigRef struct {
+	Name       string
+	NameRange  hcl.Range
+	Alias      string
+	AliasRange *hcl.Range
+}
+
+// Provisioner is an alternative representation of configs.Provisioner.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/provisioner.go#L9-L20
+type Provisioner struct {
+	Type       string
+	Config     hcl.Body
+	Connection *Connection
+	When       ProvisionerWhen
+	OnFailure  ProvisionerOnFailure
+
+	DeclRange hcl.Range
+	TypeRange hcl.Range
+}
+
+// Connection is an alternative representation of configs.Connection.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/provisioner.go#L164-L170
+type Connection struct {
+	Config hcl.Body
+
+	DeclRange hcl.Range
+}
+
+// ProvisionerWhen is an alternative representation of configs.ProvisionerWhen.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/provisioner.go#L172-L181
+type ProvisionerWhen int
+
+const (
+	// ProvisionerWhenInvalid is the zero value of ProvisionerWhen.
+	ProvisionerWhenInvalid ProvisionerWhen = iota
+	// ProvisionerWhenCreate indicates the time of creation.
+	ProvisionerWhenCreate
+	// ProvisionerWhenDestroy indicates the time of deletion.
+	ProvisionerWhenDestroy
+)
+
+// ProvisionerOnFailure is an alternative representation of configs.ProvisionerOnFailure.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/provisioner.go#L183-L193
+type ProvisionerOnFailure int
+
+const (
+	// ProvisionerOnFailureInvalid is the zero value of ProvisionerOnFailure.
+	ProvisionerOnFailureInvalid ProvisionerOnFailure = iota
+	// ProvisionerOnFailureContinue indicates continuation on failure.
+	ProvisionerOnFailureContinue
+	// ProvisionerOnFailureFail indicates failure on failure.
+	ProvisionerOnFailureFail
+)

--- a/terraform/doc.go
+++ b/terraform/doc.go
@@ -1,0 +1,8 @@
+// Package terraform contains structures for Terraform's alternative
+// representations. The reason for providing these is to avoid depending
+// on Terraform for this plugin.
+//
+// The structures provided by this package are minimal used for static analysis.
+// Also, this is often not transferred directly from the host process, but through
+// an intermediate representation. See the package tflint for details.
+package terraform

--- a/tflint/decode.go
+++ b/tflint/decode.go
@@ -1,0 +1,171 @@
+package tflint
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
+)
+
+// Resource is an intermediate representation of configs.Resource.
+type Resource struct {
+	Mode         terraform.ResourceMode
+	Name         string
+	Type         string
+	Config       []byte
+	ConfigRange  hcl.Range
+	Count        []byte
+	CountRange   hcl.Range
+	ForEach      []byte
+	ForEachRange hcl.Range
+
+	ProviderConfigRef *terraform.ProviderConfigRef
+
+	Managed *ManagedResource
+
+	DeclRange hcl.Range
+	TypeRange hcl.Range
+}
+
+func decodeResource(resource *Resource) (*terraform.Resource, hcl.Diagnostics) {
+	file, diags := parseConfig(resource.Config, resource.ConfigRange.Filename, resource.ConfigRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	var count hcl.Expression
+	if resource.Count != nil {
+		count, diags = parseExpression(resource.Count, resource.CountRange.Filename, resource.CountRange.Start)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+	}
+
+	var forEach hcl.Expression
+	if resource.ForEach != nil {
+		forEach, diags = parseExpression(resource.ForEach, resource.ForEachRange.Filename, resource.ForEachRange.Start)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+	}
+
+	managed, diags := decodeManagedResource(resource.Managed)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &terraform.Resource{
+		Mode:    resource.Mode,
+		Name:    resource.Name,
+		Type:    resource.Type,
+		Config:  file.Body,
+		Count:   count,
+		ForEach: forEach,
+
+		ProviderConfigRef: resource.ProviderConfigRef,
+
+		Managed: managed,
+
+		DeclRange: resource.DeclRange,
+		TypeRange: resource.TypeRange,
+	}, nil
+}
+
+// ManagedResource is an intermediate representation of configs.ManagedResource.
+type ManagedResource struct {
+	Connection   *Connection
+	Provisioners []*Provisioner
+
+	CreateBeforeDestroy bool
+	PreventDestroy      bool
+	IgnoreAllChanges    bool
+
+	CreateBeforeDestroySet bool
+	PreventDestroySet      bool
+}
+
+func decodeManagedResource(resource *ManagedResource) (*terraform.ManagedResource, hcl.Diagnostics) {
+	connection, diags := decodeConnection(resource.Connection)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	provisioners := make([]*terraform.Provisioner, len(resource.Provisioners))
+	for i, p := range resource.Provisioners {
+		provisioner, diags := decodeProvisioner(p)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		provisioners[i] = provisioner
+	}
+
+	return &terraform.ManagedResource{
+		Connection:   connection,
+		Provisioners: provisioners,
+
+		CreateBeforeDestroy: resource.CreateBeforeDestroy,
+		PreventDestroy:      resource.PreventDestroy,
+		IgnoreAllChanges:    resource.IgnoreAllChanges,
+
+		CreateBeforeDestroySet: resource.CreateBeforeDestroySet,
+		PreventDestroySet:      resource.PreventDestroySet,
+	}, nil
+}
+
+// Connection is an intermediate representation of configs.Connection.
+type Connection struct {
+	Config      []byte
+	ConfigRange hcl.Range
+
+	DeclRange hcl.Range
+}
+
+func decodeConnection(connection *Connection) (*terraform.Connection, hcl.Diagnostics) {
+	if connection == nil {
+		return nil, hcl.Diagnostics{}
+	}
+
+	file, diags := parseConfig(connection.Config, connection.ConfigRange.Filename, connection.ConfigRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &terraform.Connection{
+		Config:    file.Body,
+		DeclRange: connection.DeclRange,
+	}, nil
+}
+
+// Provisioner is an intermediate representation of terraform.Provisioner.
+type Provisioner struct {
+	Type        string
+	Config      []byte
+	ConfigRange hcl.Range
+	Connection  *Connection
+	When        terraform.ProvisionerWhen
+	OnFailure   terraform.ProvisionerOnFailure
+
+	DeclRange hcl.Range
+	TypeRange hcl.Range
+}
+
+func decodeProvisioner(provisioner *Provisioner) (*terraform.Provisioner, hcl.Diagnostics) {
+	file, diags := parseConfig(provisioner.Config, provisioner.ConfigRange.Filename, provisioner.ConfigRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	connection, diags := decodeConnection(provisioner.Connection)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &terraform.Provisioner{
+		Type:       provisioner.Type,
+		Config:     file.Body,
+		Connection: connection,
+		When:       provisioner.When,
+		OnFailure:  provisioner.OnFailure,
+
+		DeclRange: provisioner.DeclRange,
+		TypeRange: provisioner.TypeRange,
+	}, nil
+}

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -2,13 +2,14 @@ package tflint
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
 )
 
 // Runner acts as a client for each plugin to query the host process about the Terraform configurations.
 type Runner interface {
 	WalkResourceAttributes(string, string, func(*hcl.Attribute) error) error
 	WalkResourceBlocks(string, string, func(*hcl.Block) error) error
-	WalkResources(string, func(*Resource) error) error
+	WalkResources(string, func(*terraform.Resource) error) error
 	EvaluateExpr(expr hcl.Expression, ret interface{}) error
 	EmitIssue(rule Rule, message string, location hcl.Range, meta Metadata) error
 	EnsureNoError(error, func() error) error


### PR DESCRIPTION
Fixes #36 

Add a `terraform.Resource` equivalent to `configs.Resource` so that more information can be used by the plugin.