### PR TITLE
Add `Runner.Backend()`

### DIFF
--- a/terraform/configs.go
+++ b/terraform/configs.go
@@ -69,6 +69,16 @@ type Connection struct {
 	DeclRange hcl.Range
 }
 
+// Backend is an alternative representation of configs.Backend.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/backend.go#L12-L18
+type Backend struct {
+	Type        string
+	Config      hcl.Body
+	ConfigRange hcl.Range
+	TypeRange   hcl.Range
+	DeclRange   hcl.Range
+}
+
 // ProvisionerWhen is an alternative representation of configs.ProvisionerWhen.
 // https://github.com/hashicorp/terraform/blob/v0.12.26/configs/provisioner.go#L172-L181
 type ProvisionerWhen int

--- a/tflint/client/client.go
+++ b/tflint/client/client.go
@@ -103,6 +103,26 @@ func (c *Client) WalkResources(resource string, walker func(*terraform.Resource)
 	return nil
 }
 
+// Backend calls the server-side Backend method and returns the backend configuration.
+func (c *Client) Backend() (*terraform.Backend, error) {
+	log.Printf("[DEBUG] Backend")
+
+	var response BackendResponse
+	if err := c.rpcClient.Call("Plugin.Backend", BackendRequest{}, &response); err != nil {
+		return nil, err
+	}
+	if response.Err != nil {
+		return nil, response.Err
+	}
+
+	backend, diags := decodeBackend(response.Backend)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return backend, nil
+}
+
 // EvaluateExpr calls the server-side EvalExpr method and reflects the response
 // in the passed argument.
 func (c *Client) EvaluateExpr(expr hcl.Expression, ret interface{}) error {

--- a/tflint/client/decode.go
+++ b/tflint/client/decode.go
@@ -165,6 +165,34 @@ func decodeManagedResource(resource *ManagedResource) (*terraform.ManagedResourc
 	}, nil
 }
 
+// Backend is an intermediate representation of terraform.Backend.
+type Backend struct {
+	Type        string
+	Config      []byte
+	ConfigRange hcl.Range
+	TypeRange   hcl.Range
+	DeclRange   hcl.Range
+}
+
+func decodeBackend(backend *Backend) (*terraform.Backend, hcl.Diagnostics) {
+	if backend == nil {
+		return nil, nil
+	}
+
+	file, diags := parseConfig(backend.Config, backend.ConfigRange.Filename, backend.ConfigRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &terraform.Backend{
+		Type:        backend.Type,
+		Config:      file.Body,
+		TypeRange:   backend.TypeRange,
+		DeclRange:   backend.DeclRange,
+		ConfigRange: backend.ConfigRange,
+	}, nil
+}
+
 // Connection is an intermediate representation of terraform.Connection.
 type Connection struct {
 	Config      []byte

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -17,6 +17,15 @@ type AttributesResponse struct {
 	Err        error
 }
 
+// BackendRequest is a request to the server-side Backend method.
+type BackendRequest struct{}
+
+// BackendResponse is a response to the server-side Backend method.
+type BackendResponse struct {
+	Backend *Backend
+	Err     error
+}
+
 // BlocksRequest is a request to the server-side Blocks method.
 type BlocksRequest struct {
 	Resource  string

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -20,6 +20,9 @@ type Runner interface {
 	// You must pass a resource type as the first argument.
 	WalkResources(string, func(*terraform.Resource) error) error
 
+	// Backend returns the backend configuration, if any.
+	Backend() (*terraform.Backend, error)
+
 	// EvaluateExpr evaluates the passed expression and reflects the result in ret.
 	// Since this function returns an application error, it is expected to use the EnsureNoError
 	// to determine whether to continue processing.

--- a/tflint/server/server.go
+++ b/tflint/server/server.go
@@ -7,6 +7,7 @@ type Server interface {
 	Attributes(*client.AttributesRequest, *client.AttributesResponse) error
 	Blocks(*client.BlocksRequest, *client.BlocksResponse) error
 	Resources(*client.ResourcesRequest, *client.ResourcesResponse) error
+	Backend(*client.BackendRequest, *client.BackendResponse) error
 	EvalExpr(*client.EvalExprRequest, *client.EvalExprResponse) error
 	EmitIssue(*client.EmitIssueRequest, *interface{}) error
 }


### PR DESCRIPTION
Closes #46.

This allows rulesets developed as plugins to add lint rules based on the
configuration of the state backend.