### PR TITLE
Implement `WalkModuleCalls`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.0
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-plugin v1.3.0
+	github.com/hashicorp/go-version v1.0.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/zclconf/go-cty v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQ
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-plugin v1.3.0 h1:4d/wJojzvHV1I4i/rrjVaeuyxWrLzDE1mDCyDy8fXS8=
 github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
+github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/helper/runner.go
+++ b/helper/runner.go
@@ -135,6 +135,11 @@ func (r *Runner) WalkResources(resourceType string, walker func(*terraform.Resou
 	return nil
 }
 
+// WalkModuleCalls visits all module calls from Files.
+func (r *Runner) WalkModuleCalls(walker func(*terraform.ModuleCall) error) error {
+	return nil
+}
+
 // Backend returns the terraform backend configuration.
 func (r *Runner) Backend() (*terraform.Backend, error) {
 	for _, file := range r.Files {

--- a/helper/runner.go
+++ b/helper/runner.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
@@ -137,6 +138,32 @@ func (r *Runner) WalkResources(resourceType string, walker func(*terraform.Resou
 
 // WalkModuleCalls visits all module calls from Files.
 func (r *Runner) WalkModuleCalls(walker func(*terraform.ModuleCall) error) error {
+	for _, file := range r.Files {
+		calls, _, diags := file.Body.PartialContent(&hcl.BodySchema{
+			Blocks: []hcl.BlockHeaderSchema{
+				{
+					Type:       "module",
+					LabelNames: []string{"name"},
+				},
+			},
+		})
+		if diags.HasErrors() {
+			return diags
+		}
+
+		for _, block := range calls.Blocks {
+			call, diags := simpleDecodeModuleCallBlock(block)
+			if diags.HasErrors() {
+				return diags
+			}
+
+			err := walker(call)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -256,20 +283,9 @@ func simpleDecodeResouceBlock(resource *hcl.Block) (*terraform.Resource, hcl.Dia
 
 	var ref *terraform.ProviderConfigRef
 	if attr, exists := content.Attributes["provider"]; exists {
-		traversal, diags := hcl.AbsTraversalForExpr(attr.Expr)
+		ref, diags = decodeProviderConfigRef(attr.Expr)
 		if diags.HasErrors() {
 			return nil, diags
-		}
-
-		ref = &terraform.ProviderConfigRef{
-			Name:      traversal.RootName(),
-			NameRange: traversal[0].SourceRange(),
-		}
-
-		if len(traversal) > 1 {
-			aliasStep := traversal[1].(hcl.TraverseAttr)
-			ref.Alias = aliasStep.Name
-			ref.AliasRange = aliasStep.SourceRange().Ptr()
 		}
 	}
 
@@ -383,4 +399,110 @@ func simpleDecodeResouceBlock(resource *hcl.Block) (*terraform.Resource, hcl.Dia
 		DeclRange: resource.DefRange,
 		TypeRange: resource.LabelRanges[0],
 	}, nil
+}
+
+func simpleDecodeModuleCallBlock(block *hcl.Block) (*terraform.ModuleCall, hcl.Diagnostics) {
+	content, remain, diags := block.Body.PartialContent(&hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "source", Required: true},
+			{Name: "version"},
+			{Name: "providers"},
+		},
+	})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	var sourceAddr string
+	var sourceAddrRange hcl.Range
+	if attr, exists := content.Attributes["source"]; exists {
+		if diags := gohcl.DecodeExpression(attr.Expr, nil, &sourceAddr); diags.HasErrors() {
+			return nil, diags
+		}
+		sourceAddrRange = attr.Expr.Range()
+	}
+
+	providers := []terraform.PassedProviderConfig{}
+	if attr, exists := content.Attributes["providers"]; exists {
+		pairs, diags := hcl.ExprMap(attr.Expr)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+
+		for _, pair := range pairs {
+			key, diags := decodeProviderConfigRef(pair.Key)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+
+			value, diags := decodeProviderConfigRef(pair.Value)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+
+			providers = append(providers, terraform.PassedProviderConfig{
+				InChild:  key,
+				InParent: value,
+			})
+		}
+	}
+
+	var versionRequired version.Constraints
+	var versionValue string
+	var versionRange hcl.Range
+	var err error
+	if attr, exists := content.Attributes["version"]; exists {
+		versionRange = attr.Expr.Range()
+
+		if diags := gohcl.DecodeExpression(attr.Expr, nil, &versionValue); diags.HasErrors() {
+			return nil, diags
+		}
+
+		versionRequired, err = version.NewConstraint(versionValue)
+		if err != nil {
+			return nil, hcl.Diagnostics{
+				{Severity: hcl.DiagError, Summary: "Invalid version constraint"},
+			}
+		}
+	}
+
+	return &terraform.ModuleCall{
+		Name: block.Labels[0],
+
+		SourceAddr:      sourceAddr,
+		SourceAddrRange: sourceAddrRange,
+		SourceSet:       !sourceAddrRange.Empty(),
+
+		Config:      remain,
+		ConfigRange: block.DefRange,
+
+		Version: terraform.VersionConstraint{
+			Required:  versionRequired,
+			DeclRange: versionRange,
+		},
+
+		Providers: providers,
+
+		DeclRange: block.DefRange,
+	}, nil
+}
+
+func decodeProviderConfigRef(expr hcl.Expression) (*terraform.ProviderConfigRef, hcl.Diagnostics) {
+	traversal, diags := hcl.AbsTraversalForExpr(expr)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	ref := &terraform.ProviderConfigRef{
+		Name:      traversal.RootName(),
+		NameRange: traversal[0].SourceRange(),
+	}
+
+	if len(traversal) > 1 {
+		aliasStep := traversal[1].(hcl.TraverseAttr)
+		ref.Alias = aliasStep.Name
+		ref.AliasRange = aliasStep.SourceRange().Ptr()
+	}
+
+	return ref, nil
 }

--- a/terraform/configs.go
+++ b/terraform/configs.go
@@ -1,6 +1,9 @@
 package terraform
 
-import "github.com/hashicorp/hcl/v2"
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+)
 
 // Resource is an alternative representation of configs.Resource.
 // https://github.com/hashicorp/terraform/blob/v0.12.26/configs/resource.go#L13-L33
@@ -37,6 +40,13 @@ type ManagedResource struct {
 
 	CreateBeforeDestroySet bool
 	PreventDestroySet      bool
+}
+
+// PassedProviderConfig is an alternative representation of configs.PassedProviderConfig.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/module_call.go#L155-L158
+type PassedProviderConfig struct {
+	InChild  *ProviderConfigRef
+	InParent *ProviderConfigRef
 }
 
 // ProviderConfigRef is an alternative representation of configs.ProviderConfigRef.
@@ -77,6 +87,40 @@ type Backend struct {
 	ConfigRange hcl.Range
 	TypeRange   hcl.Range
 	DeclRange   hcl.Range
+}
+
+// ModuleCall is an alternative representation of configs.ModuleCall.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/module_call.go#L11-L31
+// DependsOn is not supported due to the difficulty of intermediate representation.
+type ModuleCall struct {
+	Name string
+
+	SourceAddr      string
+	SourceAddrRange hcl.Range
+	SourceSet       bool
+
+	Config      hcl.Body
+	ConfigRange hcl.Range
+
+	Version VersionConstraint
+
+	Count        hcl.Expression
+	CountRange   hcl.Range
+	ForEach      hcl.Expression
+	ForEachRange hcl.Range
+
+	Providers []PassedProviderConfig
+
+	// DependsOn []hcl.Traversal
+
+	DeclRange hcl.Range
+}
+
+// VersionConstraint is an alternative representation of configs.VersionConstraint.
+// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/version_constraint.go#L16-L19
+type VersionConstraint struct {
+	Required  version.Constraints
+	DeclRange hcl.Range
 }
 
 // ProvisionerWhen is an alternative representation of configs.ProvisionerWhen.

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -38,6 +38,15 @@ type BlocksResponse struct {
 	Err    error
 }
 
+// ModuleCallsRequest is a request to the server-side ModuleCalls method.
+type ModuleCallsRequest struct{}
+
+// ModuleCallsResponse is a response to the server-side ModuleCalls method.
+type ModuleCallsResponse struct {
+	ModuleCalls []*ModuleCall
+	Err         error
+}
+
 // ResourcesRequest is a request to the server-side Resources method.
 type ResourcesRequest struct {
 	Name string

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -20,6 +20,9 @@ type Runner interface {
 	// You must pass a resource type as the first argument.
 	WalkResources(string, func(*terraform.Resource) error) error
 
+	// WalkModuleCalls visits module calls with the passed function.
+	WalkModuleCalls(func(*terraform.ModuleCall) error) error
+
 	// Backend returns the backend configuration, if any.
 	Backend() (*terraform.Backend, error)
 

--- a/tflint/server/server.go
+++ b/tflint/server/server.go
@@ -7,6 +7,7 @@ type Server interface {
 	Attributes(*client.AttributesRequest, *client.AttributesResponse) error
 	Blocks(*client.BlocksRequest, *client.BlocksResponse) error
 	Resources(*client.ResourcesRequest, *client.ResourcesResponse) error
+	ModuleCalls(*client.ModuleCallsRequest, *client.ModuleCallsResponse) error
 	Backend(*client.BackendRequest, *client.BackendResponse) error
 	EvalExpr(*client.EvalExprRequest, *client.EvalExprResponse) error
 	EmitIssue(*client.EmitIssueRequest, *interface{}) error


### PR DESCRIPTION
This allows rulesets to add lints that enforce rules on module calls
rather than only on resource declarations. I plan to use it, for
instance, to constrain the different forms of addresses used for
module sources.

Version constraints may be a bit different over the wire: the type exposed
by `go-version` can't necessarily be exactly reconstructed, as they've
been normalized under the hood. The original value is still accessible
through the usual `hcl.Body.PartialContent` or similar functions, if
needed.

In Terraform 0.12, I think the `Count` and `ForEach` struct members
will never actually be set, but the corresponding Terraform types have
them, so I've included them here. Maybe they'll Just Work once 0.13 is
out of beta and support is added to tflint.