### PR TITLE
Bump protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ NOTE: This plugin system is experimental. This means that API compatibility is f
 
 ## Requirements
 
-- TFLint v0.18+
+- TFLint v0.19+
 - Go v1.14
 
 ## Usage

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -10,7 +10,7 @@ import (
 
 // handShakeConfig is used for UX. ProcotolVersion will be updated by incompatible changes.
 var handshakeConfig = plugin.HandshakeConfig{
-	ProtocolVersion:  3,
+	ProtocolVersion:  4,
 	MagicCookieKey:   "TFLINT_RULESET_PLUGIN",
 	MagicCookieValue: "5adSn1bX8nrDfgBqiAqqEkC6OE1h3iD8SqbMc5UUONx8x3xCF0KlPDsBRNDjoYDP",
 }


### PR DESCRIPTION
This release breaks the API compatibility (newly added `ModuleCalls()` endpoint), so bump the protocol version.