### PR TITLE
Accept DisabledByDefault config attribute

### DIFF
--- a/tflint/config.go
+++ b/tflint/config.go
@@ -3,7 +3,8 @@ package tflint
 // Config is a TFLint configuration applied to the plugin.
 // Currently, it is not expected that each plugin will reference this directly.
 type Config struct {
-	Rules map[string]*RuleConfig
+	Rules             map[string]*RuleConfig
+	DisabledByDefault bool
 }
 
 // RuleConfig is a TFLint's rule configuration.

--- a/tflint/ruleset.go
+++ b/tflint/ruleset.go
@@ -1,6 +1,9 @@
 package tflint
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+)
 
 // RuleSet is a list of rules that a plugin should provide.
 type RuleSet struct {
@@ -33,10 +36,17 @@ func (r *RuleSet) RuleNames() []string {
 // Currently used only to enable/disable rules.
 func (r *RuleSet) ApplyConfig(config *Config) {
 	rules := []Rule{}
+
+	if config.DisabledByDefault {
+		log.Printf("[DEBUG] Only mode is enabled. Ignoring default plugin rules")
+	}
+
 	for _, rule := range r.Rules {
 		enabled := rule.Enabled()
 		if cfg := config.Rules[rule.Name()]; cfg != nil {
 			enabled = cfg.Enabled
+		} else if config.DisabledByDefault {
+			enabled = false
 		}
 
 		if enabled {


### PR DESCRIPTION
Relates to https://github.com/terraform-linters/tflint/pull/875

Setting `DisabledByDefault = true` forces all plugin rules to be disabled by default, unless manually enabled in the `.tflint.hcl` specification, or by passing `--only RULE_NAME` on the command line.