### PR TITLE
tflint: Add `Runner.Config()`

### DIFF
--- a/terraform/addrs/module.go
+++ b/terraform/addrs/module.go
@@ -1,0 +1,5 @@
+package addrs
+
+// Module is an alternative representation of addrs.Module.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/addrs/module.go#L17
+type Module []string

--- a/terraform/configs/config.go
+++ b/terraform/configs/config.go
@@ -1,0 +1,21 @@
+package configs
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/addrs"
+)
+
+// Config is an alternative representation of configs.Config.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/config.go#L22-L78
+type Config struct {
+	// Root            *Config
+	// Parent          *Config
+	Path addrs.Module
+	// Children        map[string]*Config
+	Module          *Module
+	CallRange       hcl.Range
+	SourceAddr      string
+	SourceAddrRange hcl.Range
+	Version         *version.Version
+}

--- a/terraform/configs/module.go
+++ b/terraform/configs/module.go
@@ -1,0 +1,31 @@
+package configs
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/experiments"
+)
+
+// Module is an alternative representation of configs.Module.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/module.go#L14-L45
+type Module struct {
+	SourceDir string
+
+	CoreVersionConstraints []terraform.VersionConstraint
+
+	ActiveExperiments experiments.Set
+
+	Backend              *terraform.Backend
+	ProviderConfigs      map[string]*Provider
+	ProviderRequirements *RequiredProviders
+	ProviderLocalNames   map[terraform.Provider]string
+	ProviderMetas        map[terraform.Provider]*ProviderMeta
+
+	Variables map[string]*Variable
+	Locals    map[string]*Local
+	Outputs   map[string]*Output
+
+	ModuleCalls map[string]*terraform.ModuleCall
+
+	ManagedResources map[string]*terraform.Resource
+	DataResources    map[string]*terraform.Resource
+}

--- a/terraform/configs/named_values.go
+++ b/terraform/configs/named_values.go
@@ -1,0 +1,77 @@
+package configs
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Variable is an alternative representation of configs.Variable.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L21-L32
+type Variable struct {
+	Name        string
+	Description string
+	Default     cty.Value
+	Type        cty.Type
+	ParsingMode VariableParsingMode
+	Validations []*VariableValidation
+
+	DescriptionSet bool
+
+	DeclRange hcl.Range
+}
+
+// VariableParsingMode is an alternative representation of configs.VariableParsingMode.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L226-L234
+type VariableParsingMode rune
+
+// VariableParseLiteral is a variable parsing mode that just takes the given
+// string directly as a cty.String value.
+const VariableParseLiteral VariableParsingMode = 'L'
+
+// VariableParseHCL is a variable parsing mode that attempts to parse the given
+// string as an HCL expression and returns the result.
+const VariableParseHCL VariableParsingMode = 'H'
+
+// VariableValidation is an alternative representation of configs.VariableValidation.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L273-L289
+type VariableValidation struct {
+	// Condition is an expression that refers to the variable being tested
+	// and contains no other references. The expression must return true
+	// to indicate that the value is valid or false to indicate that it is
+	// invalid. If the expression produces an error, that's considered a bug
+	// in the module defining the validation rule, not an error in the caller.
+	Condition hcl.Expression
+
+	// ErrorMessage is one or more full sentences, which would need to be in
+	// English for consistency with the rest of the error message output but
+	// can in practice be in any language as long as it ends with a period.
+	// The message should describe what is required for the condition to return
+	// true in a way that would make sense to a caller of the module.
+	ErrorMessage string
+
+	DeclRange hcl.Range
+}
+
+// Local is an alternative representation of configs.Local.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L485-L490
+type Local struct {
+	Name string
+	Expr hcl.Expression
+
+	DeclRange hcl.Range
+}
+
+// Output is an alternative representation of configs.Output.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L422-L433
+type Output struct {
+	Name        string
+	Description string
+	Expr        hcl.Expression
+	// DependsOn   []hcl.Traversal
+	Sensitive bool
+
+	DescriptionSet bool
+	SensitiveSet   bool
+
+	DeclRange hcl.Range
+}

--- a/terraform/configs/provider.go
+++ b/terraform/configs/provider.go
@@ -1,0 +1,48 @@
+package configs
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
+)
+
+// Provider is an alternative representation of configs.Provider.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider.go#L17-L28
+type Provider struct {
+	Name       string
+	NameRange  hcl.Range
+	Alias      string
+	AliasRange *hcl.Range // nil if no alias set
+
+	Version terraform.VersionConstraint
+
+	Config hcl.Body
+
+	DeclRange hcl.Range
+}
+
+// ProviderMeta is an alternative representation of configs.ProviderMeta.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider_meta.go#L7-L13
+type ProviderMeta struct {
+	Provider string
+	Config   hcl.Body
+
+	ProviderRange hcl.Range
+	DeclRange     hcl.Range
+}
+
+// RequiredProvider is an alternative representation of configs.RequiredProvider.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider_requirements.go#L14-L20
+type RequiredProvider struct {
+	Name        string
+	Source      string
+	Type        terraform.Provider
+	Requirement terraform.VersionConstraint
+	DeclRange   hcl.Range
+}
+
+// RequiredProviders is an alternative representation of configs.RequiredProviders.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider_requirements.go#L22-L25
+type RequiredProviders struct {
+	RequiredProviders map[string]*RequiredProvider
+	DeclRange         hcl.Range
+}

--- a/terraform/experiments/experiment.go
+++ b/terraform/experiments/experiment.go
@@ -1,0 +1,9 @@
+package experiments
+
+// Experiment is an alternative representation of experiments.Experiment.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/experiments/experiment.go#L5
+type Experiment string
+
+// Set is an alternative representation of experiments.Set.
+// https://github.com/hashicorp/terraform/blob/v0.13.1/experiments/set.go#L5
+type Set map[Experiment]struct{}

--- a/tflint/client/client.go
+++ b/tflint/client/client.go
@@ -9,6 +9,7 @@ import (
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
@@ -148,6 +149,26 @@ func (c *Client) Backend() (*terraform.Backend, error) {
 	}
 
 	return backend, nil
+}
+
+// Config calls the server-side Config method and returns the Terraform configuration.
+func (c *Client) Config() (*configs.Config, error) {
+	log.Print("[DEBUG] Accessing to Config")
+
+	var response ConfigResponse
+	if err := c.rpcClient.Call("Plugin.Config", ConfigRequest{}, &response); err != nil {
+		return nil, err
+	}
+	if response.Err != nil {
+		return nil, response.Err
+	}
+
+	config, diags := decodeConfig(response.Config)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return config, nil
 }
 
 // EvaluateExpr calls the server-side EvalExpr method and reflects the response

--- a/tflint/client/decode_named_values.go
+++ b/tflint/client/decode_named_values.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Variable is an intermediate representation of configs.Variable.
+type Variable struct {
+	Name        string
+	Description string
+	Default     cty.Value
+	Type        cty.Type
+	ParsingMode configs.VariableParsingMode
+	Validations []*VariableValidation
+
+	DescriptionSet bool
+
+	DeclRange hcl.Range
+}
+
+func decodeVariable(variable *Variable) (*configs.Variable, hcl.Diagnostics) {
+	ret := make([]*configs.VariableValidation, len(variable.Validations))
+	for i, v := range variable.Validations {
+		validation, diags := decodeVariableValidation(v)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		ret[i] = validation
+	}
+
+	return &configs.Variable{
+		Name:        variable.Name,
+		Description: variable.Description,
+		Default:     variable.Default,
+		Type:        variable.Type,
+		ParsingMode: variable.ParsingMode,
+		Validations: ret,
+
+		DescriptionSet: variable.DescriptionSet,
+
+		DeclRange: variable.DeclRange,
+	}, nil
+}
+
+// VariableValidation is an intermediate representation of configs.VariableValidation.
+type VariableValidation struct {
+	Condition      []byte
+	ConditionRange hcl.Range
+
+	ErrorMessage string
+
+	DeclRange hcl.Range
+}
+
+func decodeVariableValidation(validation *VariableValidation) (*configs.VariableValidation, hcl.Diagnostics) {
+	expr, diags := parseExpression(validation.Condition, validation.ConditionRange.Filename, validation.ConditionRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &configs.VariableValidation{
+		Condition:    expr,
+		ErrorMessage: validation.ErrorMessage,
+		DeclRange:    validation.DeclRange,
+	}, nil
+}
+
+// Local is an intermediate representation of configs.Local.
+type Local struct {
+	Name      string
+	Expr      []byte
+	ExprRange hcl.Range
+
+	DeclRange hcl.Range
+}
+
+func decodeLocal(local *Local) (*configs.Local, hcl.Diagnostics) {
+	expr, diags := parseExpression(local.Expr, local.ExprRange.Filename, local.ExprRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &configs.Local{
+		Name: local.Name,
+		Expr: expr,
+
+		DeclRange: local.DeclRange,
+	}, nil
+}
+
+// Output is an intermediate representation of configs.Output.
+type Output struct {
+	Name        string
+	Description string
+	Expr        []byte
+	ExprRange   hcl.Range
+	// DependsOn   []hcl.Traversal
+	Sensitive bool
+
+	DescriptionSet bool
+	SensitiveSet   bool
+
+	DeclRange hcl.Range
+}
+
+func decodeOutput(output *Output) (*configs.Output, hcl.Diagnostics) {
+	expr, diags := parseExpression(output.Expr, output.ExprRange.Filename, output.ExprRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &configs.Output{
+		Name:        output.Name,
+		Description: output.Description,
+		Expr:        expr,
+		Sensitive:   output.Sensitive,
+
+		DescriptionSet: output.DescriptionSet,
+		SensitiveSet:   output.Sensitive,
+
+		DeclRange: output.DeclRange,
+	}, nil
+}

--- a/tflint/client/decode_provider.go
+++ b/tflint/client/decode_provider.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+)
+
+// Provider is an intermediate representation of configs.Provider.
+type Provider struct {
+	Name       string
+	NameRange  hcl.Range
+	Alias      string
+	AliasRange *hcl.Range // nil if no alias set
+
+	Version      string
+	VersionRange hcl.Range
+
+	Config      []byte
+	ConfigRange hcl.Range
+
+	DeclRange hcl.Range
+}
+
+func decodeProvider(provider *Provider) (*configs.Provider, hcl.Diagnostics) {
+	versionConstraint, diags := parseVersionConstraint(provider.Version, provider.VersionRange)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	file, diags := parseConfig(provider.Config, provider.ConfigRange.Filename, provider.ConfigRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &configs.Provider{
+		Name:       provider.Name,
+		NameRange:  provider.NameRange,
+		Alias:      provider.Alias,
+		AliasRange: provider.AliasRange,
+
+		Version: versionConstraint,
+
+		Config: file.Body,
+
+		DeclRange: provider.DeclRange,
+	}, nil
+}
+
+// ProviderMeta is an intermediate representation of configs.ProviderMeta.
+type ProviderMeta struct {
+	Provider    string
+	Config      []byte
+	ConfigRange hcl.Range
+
+	ProviderRange hcl.Range
+	DeclRange     hcl.Range
+}
+
+func decodeProviderMeta(meta *ProviderMeta) (*configs.ProviderMeta, hcl.Diagnostics) {
+	file, diags := parseConfig(meta.Config, meta.ConfigRange.Filename, meta.ConfigRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &configs.ProviderMeta{
+		Provider: meta.Provider,
+		Config:   file.Body,
+
+		ProviderRange: meta.ProviderRange,
+		DeclRange:     meta.DeclRange,
+	}, nil
+}
+
+// RequiredProvider is an intermediate representation of configs.RequiredProvider.
+type RequiredProvider struct {
+	Name             string
+	Source           string
+	Type             terraform.Provider
+	Requirement      string
+	RequirementRange hcl.Range
+	DeclRange        hcl.Range
+}
+
+func decodeRequiredProvider(provider *RequiredProvider) (*configs.RequiredProvider, hcl.Diagnostics) {
+	versionConstraint, diags := parseVersionConstraint(provider.Requirement, provider.RequirementRange)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &configs.RequiredProvider{
+		Name:        provider.Name,
+		Source:      provider.Source,
+		Type:        provider.Type,
+		Requirement: versionConstraint,
+		DeclRange:   provider.DeclRange,
+	}, nil
+}
+
+// RequiredProviders is an intermediate representation of configs.RequiredProviders.
+type RequiredProviders struct {
+	RequiredProviders map[string]*RequiredProvider
+	DeclRange         hcl.Range
+}
+
+func decodeRequiredProviders(providers *RequiredProviders) (*configs.RequiredProviders, hcl.Diagnostics) {
+	ret := map[string]*configs.RequiredProvider{}
+	for k, v := range providers.RequiredProviders {
+		p, diags := decodeRequiredProvider(v)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		ret[k] = p
+	}
+
+	return &configs.RequiredProviders{
+		RequiredProviders: ret,
+		DeclRange:         providers.DeclRange,
+	}, nil
+}

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -58,6 +58,15 @@ type ResourcesResponse struct {
 	Err       error
 }
 
+// ConfigRequest is a request to the server-side Config method.
+type ConfigRequest struct{}
+
+// ConfigResponse is a response to the server-side Config method.
+type ConfigResponse struct {
+	Config *Config
+	Err    error
+}
+
 // EvalExprRequest is a request to the server-side EvalExpr method.
 type EvalExprRequest struct {
 	Expr      []byte

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -3,6 +3,7 @@ package tflint
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 )
 
 // Runner acts as a client for each plugin to query the host process about the Terraform configurations.
@@ -25,6 +26,10 @@ type Runner interface {
 
 	// Backend returns the backend configuration, if any.
 	Backend() (*terraform.Backend, error)
+
+	// Config returns the Terraform configuration.
+	// This object contains almost all accessible data structures from plugins.
+	Config() (*configs.Config, error)
 
 	// EvaluateExpr evaluates the passed expression and reflects the result in ret.
 	// Since this function returns an application error, it is expected to use the EnsureNoError


### PR DESCRIPTION
This PR introduces `Config` function to the Runner that returns an object equivalent to `github.com/hashicorp/terraform/configs.Config`.

Through this object, you will be able to access things like variables and outputs that were previously inaccessible.