### PR TITLE
Make terraform configuration compatible with v0.13.2

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -315,7 +315,7 @@ func (r *Runner) EnsureNoError(err error, proc func() error) error {
 // simpleDecodeResourceBlock decodes the data equivalent to configs.Resource from hcl.Block
 // without depending on Terraform. Some operations have been omitted for ease of implementation.
 // As such, it is expected to parse the minimal code needed for testing.
-// https://github.com/hashicorp/terraform/blob/v0.12.26/configs/resource.go#L78-L288
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/resource.go#L80-L290
 func simpleDecodeResouceBlock(resource *hcl.Block) (*configs.Resource, hcl.Diagnostics) {
 	content, resourceRemain, diags := resource.Body.PartialContent(&hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{

--- a/terraform/addrs/module.go
+++ b/terraform/addrs/module.go
@@ -3,11 +3,11 @@ package addrs
 import svchost "github.com/hashicorp/terraform-svchost"
 
 // Module is an alternative representation of addrs.Module.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/addrs/module.go#L17
+// https://github.com/hashicorp/terraform/blob/v0.13.2/addrs/module.go#L17
 type Module []string
 
 // Provider is an alternative representation of addrs.Provider.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/addrs/provider.go#L16-L20
+// https://github.com/hashicorp/terraform/blob/v0.13.2/addrs/provider.go#L16-L20
 type Provider struct {
 	Type      string
 	Namespace string
@@ -15,7 +15,7 @@ type Provider struct {
 }
 
 // ResourceMode is an alternative representation of addrs.ResourceMode.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/addrs/resource.go#L326-L344
+// https://github.com/hashicorp/terraform/blob/v0.13.2/addrs/resource.go#L326-L344
 type ResourceMode rune
 
 const (

--- a/terraform/configs/backend.go
+++ b/terraform/configs/backend.go
@@ -3,7 +3,7 @@ package configs
 import "github.com/hashicorp/hcl/v2"
 
 // Backend is an alternative representation of configs.Backend.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/backend.go#L12-L18
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/backend.go#L12-L18
 type Backend struct {
 	Type   string
 	Config hcl.Body

--- a/terraform/configs/config.go
+++ b/terraform/configs/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Config is an alternative representation of configs.Config.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/config.go#L22-L78
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/config.go#L22-L78
 type Config struct {
 	// Root            *Config
 	// Parent          *Config

--- a/terraform/configs/module.go
+++ b/terraform/configs/module.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Module is an alternative representation of configs.Module.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/module.go#L14-L45
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/module.go#L14-L45
 type Module struct {
 	SourceDir string
 

--- a/terraform/configs/module_call.go
+++ b/terraform/configs/module_call.go
@@ -3,7 +3,7 @@ package configs
 import "github.com/hashicorp/hcl/v2"
 
 // ModuleCall is an alternative representation of configs.ModuleCall.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/module_call.go#L12-L31
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/module_call.go#L12-L31
 // DependsOn is not supported due to the difficulty of intermediate representation.
 type ModuleCall struct {
 	Name string
@@ -27,7 +27,7 @@ type ModuleCall struct {
 }
 
 // PassedProviderConfig is an alternative representation of configs.PassedProviderConfig.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/module_call.go#L140-L143
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/module_call.go#L140-L143
 type PassedProviderConfig struct {
 	InChild  *ProviderConfigRef
 	InParent *ProviderConfigRef

--- a/terraform/configs/named_values.go
+++ b/terraform/configs/named_values.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Variable is an alternative representation of configs.Variable.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L21-L32
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/named_values.go#L21-L32
 type Variable struct {
 	Name        string
 	Description string
@@ -21,7 +21,7 @@ type Variable struct {
 }
 
 // VariableParsingMode is an alternative representation of configs.VariableParsingMode.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L226-L234
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/named_values.go#L226-L234
 type VariableParsingMode rune
 
 // VariableParseLiteral is a variable parsing mode that just takes the given
@@ -33,7 +33,7 @@ const VariableParseLiteral VariableParsingMode = 'L'
 const VariableParseHCL VariableParsingMode = 'H'
 
 // VariableValidation is an alternative representation of configs.VariableValidation.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L273-L289
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/named_values.go#L273-L289
 type VariableValidation struct {
 	// Condition is an expression that refers to the variable being tested
 	// and contains no other references. The expression must return true
@@ -53,7 +53,7 @@ type VariableValidation struct {
 }
 
 // Local is an alternative representation of configs.Local.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L485-L490
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/named_values.go#L485-L490
 type Local struct {
 	Name string
 	Expr hcl.Expression
@@ -62,7 +62,7 @@ type Local struct {
 }
 
 // Output is an alternative representation of configs.Output.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/named_values.go#L422-L433
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/named_values.go#L422-L433
 type Output struct {
 	Name        string
 	Description string

--- a/terraform/configs/provider.go
+++ b/terraform/configs/provider.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Provider is an alternative representation of configs.Provider.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider.go#L17-L28
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provider.go#L17-L28
 type Provider struct {
 	Name       string
 	NameRange  hcl.Range
@@ -21,7 +21,7 @@ type Provider struct {
 }
 
 // ProviderMeta is an alternative representation of configs.ProviderMeta.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider_meta.go#L7-L13
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provider_meta.go#L7-L13
 type ProviderMeta struct {
 	Provider string
 	Config   hcl.Body
@@ -31,7 +31,7 @@ type ProviderMeta struct {
 }
 
 // RequiredProvider is an alternative representation of configs.RequiredProvider.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider_requirements.go#L14-L20
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provider_requirements.go#L14-L20
 type RequiredProvider struct {
 	Name        string
 	Source      string
@@ -41,7 +41,7 @@ type RequiredProvider struct {
 }
 
 // RequiredProviders is an alternative representation of configs.RequiredProviders.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provider_requirements.go#L22-L25
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provider_requirements.go#L22-L25
 type RequiredProviders struct {
 	RequiredProviders map[string]*RequiredProvider
 	DeclRange         hcl.Range

--- a/terraform/configs/provisioner.go
+++ b/terraform/configs/provisioner.go
@@ -3,7 +3,7 @@ package configs
 import "github.com/hashicorp/hcl/v2"
 
 // Provisioner is an alternative representation of configs.Provisioner.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provisioner.go#L11-L20
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provisioner.go#L11-L20
 type Provisioner struct {
 	Type       string
 	Config     hcl.Body
@@ -16,7 +16,7 @@ type Provisioner struct {
 }
 
 // Connection is an alternative representation of configs.Connection.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provisioner.go#L166-L170
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provisioner.go#L166-L170
 type Connection struct {
 	Config hcl.Body
 
@@ -24,7 +24,7 @@ type Connection struct {
 }
 
 // ProvisionerWhen is an alternative representation of configs.ProvisionerWhen.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provisioner.go#L172-L181
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provisioner.go#L172-L181
 type ProvisionerWhen int
 
 const (
@@ -37,7 +37,7 @@ const (
 )
 
 // ProvisionerOnFailure is an alternative representation of configs.ProvisionerOnFailure.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/provisioner.go#L183-L193
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/provisioner.go#L183-L193
 type ProvisionerOnFailure int
 
 const (

--- a/terraform/configs/resource.go
+++ b/terraform/configs/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Resource is an alternative representation of configs.Resource.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/resource.go#L14-L34
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/resource.go#L14-L34
 // DependsOn is not supported due to the difficulty of intermediate representation.
 type Resource struct {
 	Mode    addrs.ResourceMode
@@ -28,7 +28,7 @@ type Resource struct {
 }
 
 // ManagedResource is an alternative representation of configs.ManagedResource.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/resource.go#L37-L48
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/resource.go#L37-L48
 // IgnoreChanges is not supported due to the difficulty of intermediate representation.
 type ManagedResource struct {
 	Connection   *Connection
@@ -44,7 +44,7 @@ type ManagedResource struct {
 }
 
 // ProviderConfigRef is an alternative representation of configs.ProviderConfigRef.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/resource.go#L373-L378
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/resource.go#L373-L378
 type ProviderConfigRef struct {
 	Name       string
 	NameRange  hcl.Range

--- a/terraform/configs/version_constraint.go
+++ b/terraform/configs/version_constraint.go
@@ -6,7 +6,7 @@ import (
 )
 
 // VersionConstraint is an alternative representation of configs.VersionConstraint.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/configs/version_constraint.go#L16-L19
+// https://github.com/hashicorp/terraform/blob/v0.13.2/configs/version_constraint.go#L16-L19
 type VersionConstraint struct {
 	Required  version.Constraints
 	DeclRange hcl.Range

--- a/terraform/experiments/experiment.go
+++ b/terraform/experiments/experiment.go
@@ -1,9 +1,9 @@
 package experiments
 
 // Experiment is an alternative representation of experiments.Experiment.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/experiments/experiment.go#L5
+// https://github.com/hashicorp/terraform/blob/v0.13.2/experiments/experiment.go#L5
 type Experiment string
 
 // Set is an alternative representation of experiments.Set.
-// https://github.com/hashicorp/terraform/blob/v0.13.1/experiments/set.go#L5
+// https://github.com/hashicorp/terraform/blob/v0.13.2/experiments/set.go#L5
 type Set map[Experiment]struct{}


### PR DESCRIPTION
This PR makes Terraform structures compatible with v0.13.2. There are no changes to the code.