### PR TITLE
Add support for JSON configuration syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-plugin v1.3.0
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcl/v2 v2.6.0
+	github.com/hashicorp/hcl/v2 v2.7.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
 	github.com/zclconf/go-cty v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYt
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
-github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
+github.com/hashicorp/hcl/v2 v2.7.0 h1:IU8qz5UzZ1po3M1D9/Kq6S5zbDGVfI9bnzmC1ogKKmI=
+github.com/hashicorp/hcl/v2 v2.7.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/tflint/client/decode.go
+++ b/tflint/client/decode.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-version"
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 )
 
@@ -67,13 +68,7 @@ func parseExpression(src []byte, filename string, start hcl.Pos) (hcl.Expression
 	}
 
 	if strings.HasSuffix(filename, ".tf.json") {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "JSON configuration syntax is not supported",
-				Subject:  &hcl.Range{Filename: filename, Start: start, End: start},
-			},
-		}
+		return json.ParseExpressionWithStartPos(src, filename, start)
 	}
 
 	panic(fmt.Sprintf("Unexpected file: %s", filename))
@@ -85,13 +80,7 @@ func parseConfig(src []byte, filename string, start hcl.Pos) (*hcl.File, hcl.Dia
 	}
 
 	if strings.HasSuffix(filename, ".tf.json") {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "JSON configuration syntax is not supported",
-				Subject:  &hcl.Range{Filename: filename, Start: start, End: start},
-			},
-		}
+		return json.ParseWithStartPos(src, filename, start)
 	}
 
 	panic(fmt.Sprintf("Unexpected file: %s", filename))


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-plugin-sdk/issues/32

HCL v2.7.0 has started to support parse JSON config/expression partially. We can take advantage of this to achieve partial server/client transfers of JSON configuration syntax.