### PR TITLE
Allow serving custom RuleSet by plugins

### DIFF
--- a/plugin/client.go
+++ b/plugin/client.go
@@ -60,7 +60,7 @@ func (c *Client) RuleNames() ([]string, error) {
 }
 
 // ApplyConfig calls the server-side ApplyConfig method.
-func (c *Client) ApplyConfig(config *tflint.Config) error {
+func (c *Client) ApplyConfig(config *tflint.MarshalledConfig) error {
 	return c.rpcClient.Call("Plugin.ApplyConfig", config, new(interface{}))
 }
 

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -47,9 +47,12 @@ func (s *Server) RuleNames(args interface{}, resp *[]string) error {
 }
 
 // ApplyConfig applies the passed config to its own plugin implementation.
-func (s *Server) ApplyConfig(config *tflint.Config, resp *interface{}) error {
-	s.impl.ApplyConfig(config)
-	return nil
+func (s *Server) ApplyConfig(config *tflint.MarshalledConfig, resp *interface{}) error {
+	cfg, err := config.Unmarshal()
+	if err != nil {
+		return err
+	}
+	return s.impl.ApplyConfig(cfg)
 }
 
 // Check calls its own plugin implementation with an RPC client that can send

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -1,14 +1,42 @@
 package tflint
 
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
 // Config is a TFLint configuration applied to the plugin.
-// Currently, it is not expected that each plugin will reference this directly.
+// The Body contains the contents declared in the "plugin" block.
 type Config struct {
 	Rules             map[string]*RuleConfig
 	DisabledByDefault bool
+	Body              hcl.Body
 }
 
 // RuleConfig is a TFLint's rule configuration.
 type RuleConfig struct {
 	Name    string
 	Enabled bool
+}
+
+// MarshalledConfig is an intermediate representation of Config for communicating over RPC
+type MarshalledConfig struct {
+	Rules             map[string]*RuleConfig
+	DisabledByDefault bool
+	BodyBytes         []byte
+	BodyRange         hcl.Range
+}
+
+// Unmarshal converts intermediate representations into the Config object.
+func (c *MarshalledConfig) Unmarshal() (*Config, error) {
+	file, diags := hclsyntax.ParseConfig(c.BodyBytes, c.BodyRange.Filename, c.BodyRange.Start)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &Config{
+		Rules:             c.Rules,
+		DisabledByDefault: c.DisabledByDefault,
+		Body:              file.Body,
+	}, nil
 }

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -5,6 +5,29 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 )
 
+// RuleSet is a list of rules that a plugin should provide.
+// Normally, plugins can use BuiltinRuleSet directly,
+// but you can also use custom rulesets that satisfy this interface.
+type RuleSet interface {
+	// RuleSetName is the name of the ruleset. This method is not expected to be overridden.
+	RuleSetName() string
+
+	// RuleSetVersion is the version of the plugin. This method is not expected to be overridden.
+	RuleSetVersion() string
+
+	// RuleNames is a list of rule names provided by the plugin. This method is not expected to be overridden.
+	RuleNames() []string
+
+	// ApplyConfig reflects the configuration to the ruleset.
+	// Custom rulesets can override this method to reflect the plugin's own configuration.
+	// In that case, don't forget to call ApplyCommonConfig.
+	ApplyConfig(*Config) error
+
+	// Check runs inspection for each rule by applying Runner.
+	// This is a entrypoint for all inspections and can be used as a hook to inject a custom runner.
+	Check(Runner) error
+}
+
 // Runner acts as a client for each plugin to query the host process about the Terraform configurations.
 type Runner interface {
 	// WalkResourceAttributes visits attributes with the passed function.


### PR DESCRIPTION
This PR changes the `tflint.Ruleset` struct to the interface. This allows each plugin to serve a custom ruleset.

The previous behavior can be reproduced by using the `tflint.BuiltinRuleSet`. If you do not need plugin-specific processing, please use `tflint.BuiltinRuleSet` directly.

Custom rulesets can be used by declared a RuleSet with a `tflint.BuiltinRuleSet` embedded in the plugin and serving it. By overwriting the following method, you can insert the process specific to the plugin.

- `ApplyConfig`
  - The argument `tflint.Config` contains the `hcl.Body` defined in the "plugin" block. You can handle plugin-specific configurations by decoding this with a custom ruleset.
- `Check`
  - You can generate custom configurations built with `ApplyConfig`, custom runners that wrap provider API clients, etc., and apply them to plugin rules.