### PR TITLE
helper: Update helper runner

### DIFF
--- a/helper/testing.go
+++ b/helper/testing.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -25,6 +26,9 @@ func TestRunner(t *testing.T, files map[string]string) *Runner {
 		runner.Files[name] = file
 	}
 
+	if err := runner.initFromFiles(); err != nil {
+		panic(fmt.Sprintf("Failed to initialize runner: %s", err))
+	}
 	return runner
 }
 


### PR DESCRIPTION
This PR extends the helper runner for testing. The following features are added:

- `cty.Value` is converted internally. This makes it possible to handle tuples and sets
- Decode `hcl.File` at initialization
- Support input variables in `EvaluateExpr`