### PR TITLE
tflint: Extend runner API for accessing the root provider configuration

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -118,6 +118,12 @@ func (r *Runner) Config() (*configs.Config, error) {
 	return r.config, nil
 }
 
+// RootProvider returns the provider configuration.
+// In the helper runner, it always returns its own provider.
+func (r *Runner) RootProvider(name string) (*configs.Provider, error) {
+	return r.config.Module.ProviderConfigs[name], nil
+}
+
 // EvaluateExpr returns a value of the passed expression.
 // Note that some features are limited
 func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
@@ -157,6 +163,12 @@ func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
 	}
 
 	return gocty.FromCtyValue(val, ret)
+}
+
+// EvaluateExprOnRootCtx returns a value of the passed expression.
+// Note this is just alias of EvaluateExpr.
+func (r *Runner) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}) error {
+	return r.EvaluateExpr(expr, ret)
 }
 
 // EmitIssueOnExpr adds an issue to the runner itself.

--- a/tflint/client/decode_provider.go
+++ b/tflint/client/decode_provider.go
@@ -23,6 +23,10 @@ type Provider struct {
 }
 
 func decodeProvider(provider *Provider) (*configs.Provider, hcl.Diagnostics) {
+	if provider == nil {
+		return nil, nil
+	}
+
 	versionConstraint, diags := parseVersionConstraint(provider.Version, provider.VersionRange)
 	if diags.HasErrors() {
 		return nil, diags

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -67,6 +67,17 @@ type ConfigResponse struct {
 	Err    error
 }
 
+// RootProviderRequest is a request to the server-side RootProvider method.
+type RootProviderRequest struct {
+	Name string
+}
+
+// RootProviderResponse is a response to the server-side RootProvider method.
+type RootProviderResponse struct {
+	Provider *Provider
+	Err      error
+}
+
 // EvalExprRequest is a request to the server-side EvalExpr method.
 type EvalExprRequest struct {
 	Expr      []byte

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -53,10 +53,18 @@ type Runner interface {
 	// This object contains almost all accessible data structures from plugins.
 	Config() (*configs.Config, error)
 
+	// RootProvider returns the provider configuration in the root module.
+	// It can be used by child modules to access the credentials defined in the root module.
+	RootProvider(name string) (*configs.Provider, error)
+
 	// EvaluateExpr evaluates the passed expression and reflects the result in ret.
 	// Since this function returns an application error, it is expected to use the EnsureNoError
 	// to determine whether to continue processing.
 	EvaluateExpr(expr hcl.Expression, ret interface{}) error
+
+	// EvaluateExprOnRootCtx is the equivalent of EvaluateExpr method in the context of the root module.
+	// Its main use is to evaluate the provider block obtained by the RootProvider method.
+	EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}) error
 
 	// EmitIssue sends an issue with an expression to TFLint. You need to pass the message of the issue and the expression.
 	EmitIssueOnExpr(rule Rule, message string, expr hcl.Expression) error


### PR DESCRIPTION
To cut out deep checking of AWS rules into a plugin, this PR extends runner API, adds `RootProvider` and `EvalExprOnRootCtx`.

In the ruleset plugin, an RPC server is assigned to each runner (module). If the target of the inspection is the root module, the provider configuration can be accessed, but the child module cannot access the provider configuration defined in the root.

To solve this problem, make use of the extended API to always have access to the root configuration.

See also https://github.com/terraform-linters/tflint/pull/986