### PR TITLE
tflint: Add support for fetching rule config

### DIFF
--- a/helper/testing.go
+++ b/helper/testing.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
@@ -23,7 +24,16 @@ func TestRunner(t *testing.T, files map[string]string) *Runner {
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}
-		runner.Files[name] = file
+
+		if name == ".tflint.hcl" {
+			var config Config
+			if diags := gohcl.DecodeBody(file.Body, nil, &config); diags.HasErrors() {
+				t.Fatal(diags)
+			}
+			runner.config = config
+		} else {
+			runner.Files[name] = file
+		}
 	}
 
 	if err := runner.initFromFiles(); err != nil {

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -78,6 +78,19 @@ type RootProviderResponse struct {
 	Err      error
 }
 
+// RuleConfigRequest is a request to the server-side RuleConfig method.
+type RuleConfigRequest struct {
+	Name string
+}
+
+// RuleConfigResponse is a response to the server-side RuleConfig method.
+type RuleConfigResponse struct {
+	Exists bool
+	Config []byte
+	Range  hcl.Range
+	Err    error
+}
+
 // EvalExprRequest is a request to the server-side EvalExpr method.
 type EvalExprRequest struct {
 	Expr      []byte

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -57,6 +57,9 @@ type Runner interface {
 	// It can be used by child modules to access the credentials defined in the root module.
 	RootProvider(name string) (*configs.Provider, error)
 
+	// DecodeRuleConfig fetches the rule's configuration and reflects the result in ret.
+	DecodeRuleConfig(name string, ret interface{}) error
+
 	// EvaluateExpr evaluates the passed expression and reflects the result in ret.
 	// Since this function returns an application error, it is expected to use the EnsureNoError
 	// to determine whether to continue processing.


### PR DESCRIPTION
This PR adds an API for fetching rule config from plugins.

Add the `RuleConfig` method to the plugin server and return the encoded rule's configuration. The `DecodeRuleConfig` method added to the `Runner` decodes the acquired configuration into HCL and decodes it into a structure.