### PR TITLE
tflint: Add wantType argument to EvaluateExpr

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -153,23 +153,29 @@ func (r *Runner) DecodeRuleConfig(name string, ret interface{}) error {
 
 // EvaluateExpr returns a value of the passed expression.
 // Note that some features are limited
-func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
+func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}, wantTy *cty.Type) error {
 	var wantType cty.Type
-	switch ret.(type) {
-	case *string, string:
-		wantType = cty.String
-	case *int, int:
-		wantType = cty.Number
-	case *[]string, []string:
-		wantType = cty.List(cty.String)
-	case *[]int, []int:
-		wantType = cty.List(cty.Number)
-	case *map[string]string, map[string]string:
-		wantType = cty.Map(cty.String)
-	case *map[string]int, map[string]int:
-		wantType = cty.Map(cty.Number)
-	default:
-		panic(fmt.Errorf("Unexpected result type: %T", ret))
+
+	if wantTy != nil {
+		wantType = *wantTy
+	}
+	if wantType == (cty.Type{}) {
+		switch ret.(type) {
+		case *string, string:
+			wantType = cty.String
+		case *int, int:
+			wantType = cty.Number
+		case *[]string, []string:
+			wantType = cty.List(cty.String)
+		case *[]int, []int:
+			wantType = cty.List(cty.Number)
+		case *map[string]string, map[string]string:
+			wantType = cty.Map(cty.String)
+		case *map[string]int, map[string]int:
+			wantType = cty.Map(cty.Number)
+		default:
+			panic(fmt.Errorf("Unexpected result type: %T", ret))
+		}
 	}
 
 	variables := map[string]cty.Value{}
@@ -194,8 +200,8 @@ func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
 
 // EvaluateExprOnRootCtx returns a value of the passed expression.
 // Note this is just alias of EvaluateExpr.
-func (r *Runner) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}) error {
-	return r.EvaluateExpr(expr, ret)
+func (r *Runner) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}, wantType *cty.Type) error {
+	return r.EvaluateExpr(expr, ret, wantType)
 }
 
 // EmitIssueOnExpr adds an issue to the runner itself.

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -369,7 +369,7 @@ resource "aws_instance" "foo" {
 
 	err := runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
 		var instanceType string
-		if err := runner.EvaluateExpr(attribute.Expr, &instanceType); err != nil {
+		if err := runner.EvaluateExpr(attribute.Expr, &instanceType, nil); err != nil {
 			t.Fatal(err)
 		}
 

--- a/tflint/client/client.go
+++ b/tflint/client/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
@@ -221,7 +222,11 @@ func (c *Client) DecodeRuleConfig(name string, ret interface{}) error {
 
 // EvaluateExpr calls the server-side EvalExpr method and reflects the response
 // in the passed argument.
-func (c *Client) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
+func (c *Client) EvaluateExpr(expr hcl.Expression, ret interface{}, wantType *cty.Type) error {
+	if wantType == nil {
+		wantType = &cty.Type{}
+	}
+
 	var response EvalExprResponse
 	var err error
 
@@ -229,7 +234,7 @@ func (c *Client) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
 	if err != nil {
 		return err
 	}
-	req := EvalExprRequest{Ret: ret}
+	req := EvalExprRequest{Ret: ret, Type: *wantType}
 	req.Expr, req.ExprRange = encodeExpr(src, expr)
 	if err := c.rpcClient.Call("Plugin.EvalExpr", req, &response); err != nil {
 		return err
@@ -258,7 +263,11 @@ func (c *Client) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
 
 // EvaluateExprOnRootCtx calls the server-side EvalExprOnRootCtx method and reflects the response
 // in the passed argument.
-func (c *Client) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}) error {
+func (c *Client) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}, wantType *cty.Type) error {
+	if wantType == nil {
+		wantType = &cty.Type{}
+	}
+
 	var response EvalExprResponse
 	var err error
 
@@ -266,7 +275,7 @@ func (c *Client) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}) err
 	if err != nil {
 		return err
 	}
-	req := EvalExprRequest{Ret: ret}
+	req := EvalExprRequest{Ret: ret, Type: *wantType}
 	req.Expr, req.ExprRange = encodeExpr(src, expr)
 	if err := c.rpcClient.Call("Plugin.EvalExprOnRootCtx", req, &response); err != nil {
 		return err

--- a/tflint/client/client_test.go
+++ b/tflint/client/client_test.go
@@ -354,7 +354,7 @@ func Test_EvaluateExpr(t *testing.T) {
 	}
 
 	var ret string
-	if err := client.EvaluateExpr(expr, &ret); err != nil {
+	if err := client.EvaluateExpr(expr, &ret, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -95,6 +95,7 @@ type RuleConfigResponse struct {
 type EvalExprRequest struct {
 	Expr      []byte
 	ExprRange hcl.Range
+	Type      cty.Type
 	Ret       interface{}
 }
 

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -3,6 +3,7 @@ package tflint
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // RuleSet is a list of rules that a plugin should provide.
@@ -61,13 +62,15 @@ type Runner interface {
 	DecodeRuleConfig(name string, ret interface{}) error
 
 	// EvaluateExpr evaluates the passed expression and reflects the result in ret.
+	// If you want to ensure the type of ret, you can pass the type as the 3rd argument.
+	// If you pass nil as the type, it will be inferred from the type of ret.
 	// Since this function returns an application error, it is expected to use the EnsureNoError
 	// to determine whether to continue processing.
-	EvaluateExpr(expr hcl.Expression, ret interface{}) error
+	EvaluateExpr(expr hcl.Expression, ret interface{}, wantType *cty.Type) error
 
 	// EvaluateExprOnRootCtx is the equivalent of EvaluateExpr method in the context of the root module.
 	// Its main use is to evaluate the provider block obtained by the RootProvider method.
-	EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}) error
+	EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}, wantType *cty.Type) error
 
 	// EmitIssue sends an issue with an expression to TFLint. You need to pass the message of the issue and the expression.
 	EmitIssueOnExpr(rule Rule, message string, expr hcl.Expression) error


### PR DESCRIPTION
This PR extends the `EvaluateExpr` API to add the `wantType` argument. This allows the mapping of the evaluated value to a complex object.

If you don't need to pass the type explicitly, you can pass `nil` to keep it working as before.