### PR TITLE
tflint: Add `IsNullExpr` API

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -204,6 +204,16 @@ func (r *Runner) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}, wan
 	return r.EvaluateExpr(expr, ret, wantType)
 }
 
+// IsNullExpr checks whether the passed expression is null or not.
+// Note that it does not eval the expression for simplify the implementation.
+func (r *Runner) IsNullExpr(expr hcl.Expression) (bool, error) {
+	val, diags := expr.Value(nil)
+	if diags.HasErrors() {
+		return false, diags
+	}
+	return val.IsNull(), nil
+}
+
 // EmitIssueOnExpr adds an issue to the runner itself.
 func (r *Runner) EmitIssueOnExpr(rule tflint.Rule, message string, expr hcl.Expression) error {
 	r.Issues = append(r.Issues, &Issue{

--- a/tflint/client/client.go
+++ b/tflint/client/client.go
@@ -302,6 +302,23 @@ func (c *Client) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}, wan
 	return nil
 }
 
+// IsNullExpr calls the server-side IsNullExpr method with the passed expression.
+func (c *Client) IsNullExpr(expr hcl.Expression) (bool, error) {
+	var response IsNullExprResponse
+
+	src, err := ioutil.ReadFile(expr.Range().Filename)
+	if err != nil {
+		return false, err
+	}
+	req := &IsNullExprRequest{}
+	req.Expr, req.Range = encodeExpr(src, expr)
+	if err := c.rpcClient.Call("Plugin.IsNullExpr", req, &response); err != nil {
+		return false, err
+	}
+
+	return response.Ret, response.Err
+}
+
 // EmitIssueOnExpr calls the server-side EmitIssue method with the passed expression.
 func (c *Client) EmitIssueOnExpr(rule tflint.Rule, message string, expr hcl.Expression) error {
 	req := &EmitIssueRequest{

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -105,6 +105,18 @@ type EvalExprResponse struct {
 	Err error
 }
 
+// IsNullExprRequest is a request to the server-side IsNullExpr method.
+type IsNullExprRequest struct {
+	Expr  []byte
+	Range hcl.Range
+}
+
+// IsNullExprResponse is a response to the server-side IsNullExpr method.
+type IsNullExprResponse struct {
+	Ret bool
+	Err error
+}
+
 // EmitIssueRequest is a request to the server-side EmitIssue method.
 type EmitIssueRequest struct {
 	Rule      *Rule

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -72,6 +72,10 @@ type Runner interface {
 	// Its main use is to evaluate the provider block obtained by the RootProvider method.
 	EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}, wantType *cty.Type) error
 
+	// IsNullExpr checks whether the passed expression is null or not.
+	// This returns an error when the passed expression is invalid, occurs evaluation errors, etc.
+	IsNullExpr(expr hcl.Expression) (bool, error)
+
 	// EmitIssue sends an issue with an expression to TFLint. You need to pass the message of the issue and the expression.
 	EmitIssueOnExpr(rule Rule, message string, expr hcl.Expression) error
 


### PR DESCRIPTION
This PR adds `IsNullExpr` runner API for checking whether the expression is null or not.
This is the last piece needed to cut out AWS rules into a plugin.