### PR TITLE
Avoid to read file directly from plugin side

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -131,6 +131,11 @@ func (r *Runner) Config() (*configs.Config, error) {
 	return r.tfconfig, nil
 }
 
+// File returns the hcl.File object
+func (r *Runner) File(filename string) (*hcl.File, error) {
+	return r.Files[filename], nil
+}
+
 // RootProvider returns the provider configuration.
 // In the helper runner, it always returns its own provider.
 func (r *Runner) RootProvider(name string) (*configs.Provider, error) {

--- a/tflint/client/rpc.go
+++ b/tflint/client/rpc.go
@@ -67,6 +67,17 @@ type ConfigResponse struct {
 	Err    error
 }
 
+// FileRequest is a request to the server-side File method.
+type FileRequest struct {
+	Filename string
+}
+
+// FileResponse is a response to the server-side File method.
+type FileResponse struct {
+	Bytes []byte
+	Range hcl.Range
+}
+
 // RootProviderRequest is a request to the server-side RootProvider method.
 type RootProviderRequest struct {
 	Name string

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -54,6 +54,11 @@ type Runner interface {
 	// This object contains almost all accessible data structures from plugins.
 	Config() (*configs.Config, error)
 
+	// File returns the hcl.File object.
+	// This is low level API for accessing information such as comments and syntax.
+	// When accessing resources, expressions, etc, it is recommended to use high-level APIs.
+	File(string) (*hcl.File, error)
+
 	// RootProvider returns the provider configuration in the root module.
 	// It can be used by child modules to access the credentials defined in the root module.
 	RootProvider(name string) (*configs.Provider, error)


### PR DESCRIPTION
This PR changes the way the plugin client gets bytes in HCL files.

Previously, the client read files from the disk directly. It works because the plugin process is always in the same directory as the host process. However, language server chdirs to the directory of the opened file and does not work properly in that case.

To solve this problem, the host process should read the bytes of the file, and the plugin will fetch it via RPC. This PR adds the `File` API and replace the existing` ioutil.ReadFile` with this API calls.