### PR TITLE
tflint: Add workaround for parsing heredoc expressions

### DIFF
--- a/tflint/client/decode.go
+++ b/tflint/client/decode.go
@@ -64,6 +64,9 @@ func decodeBlock(block *Block) (*hcl.Block, hcl.Diagnostics) {
 
 func parseExpression(src []byte, filename string, start hcl.Pos) (hcl.Expression, hcl.Diagnostics) {
 	if strings.HasSuffix(filename, ".tf") {
+		// HACK: Always add a newline to avoid heredoc parse errors.
+		// @see https://github.com/hashicorp/hcl/issues/441
+		src = []byte(string(src) + "\n")
 		return hclsyntax.ParseExpression(src, filename, start)
 	}
 


### PR DESCRIPTION
See https://github.com/hashicorp/hcl/issues/441

Added a workaround for this bug.