### PR TITLE
Allow use of ${terraform.workspace} in tests

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -187,9 +188,16 @@ func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}, wantTy *cty.
 	for _, variable := range r.tfconfig.Module.Variables {
 		variables[variable.Name] = variable.Default
 	}
+	workspace, success := os.LookupEnv("TERRAFORM_WORKSPACE")
+	if !success {
+		workspace = "default"
+	}
 	rawVal, diags := expr.Value(&hcl.EvalContext{
 		Variables: map[string]cty.Value{
 			"var": cty.ObjectVal(variables),
+			"terraform": cty.ObjectVal(map[string]cty.Value{
+				"workspace": cty.StringVal(workspace),
+			}),
 		},
 	})
 	if diags.HasErrors() {


### PR DESCRIPTION
I'm working on a plugin which checks that resource names include
`${terraform.workspace}` (if it's set) -
https://github.com/richardTowers/tflint-ruleset-workspaces/

Currently it's not possible to test this functionality, because (unlike
tflint) tflint-plugin-sdk doesn't support the `${terraform.workspace}`
expression.

Fixing https://github.com/terraform-linters/tflint-plugin-sdk/issues/64
would be nicer, but as this is quite self contained I think it's okay to
add this feature to the TestRunner.