### PR TITLE
tflint: Make sure RuleNames always return all rules

### DIFF
--- a/tflint/ruleset.go
+++ b/tflint/ruleset.go
@@ -11,6 +11,8 @@ type BuiltinRuleSet struct {
 	Name    string
 	Version string
 	Rules   []Rule
+
+	EnabledRules []Rule
 }
 
 // RuleSetName is the name of the ruleset.
@@ -42,7 +44,7 @@ func (r *BuiltinRuleSet) ApplyConfig(config *Config) error {
 
 // ApplyCommonConfig reflects common configurations regardless of plugins.
 func (r *BuiltinRuleSet) ApplyCommonConfig(config *Config) {
-	rules := []Rule{}
+	r.EnabledRules = []Rule{}
 
 	if config.DisabledByDefault {
 		log.Printf("[DEBUG] Only mode is enabled. Ignoring default plugin rules")
@@ -57,15 +59,14 @@ func (r *BuiltinRuleSet) ApplyCommonConfig(config *Config) {
 		}
 
 		if enabled {
-			rules = append(rules, rule)
+			r.EnabledRules = append(r.EnabledRules, rule)
 		}
 	}
-	r.Rules = rules
 }
 
 // Check runs inspection for each rule by applying Runner.
 func (r *BuiltinRuleSet) Check(runner Runner) error {
-	for _, rule := range r.Rules {
+	for _, rule := range r.EnabledRules {
 		if err := rule.Check(runner); err != nil {
 			return fmt.Errorf("Failed to check `%s` rule: %s", rule.Name(), err)
 		}


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1043 https://github.com/terraform-linters/tflint/issues/1054

This PR adds the `EnabledRules` field to the` BuiltinRuleSet` so that it doesn't change the `Rules` field.

The `Rules` field always returns all rules provided by the ruleset, regardless of the configuration, so that the validation behavior doesn't change with or without the configuration applied.