### PR TITLE
Use a consistent env var for TF_WORKSPACE

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -188,7 +188,7 @@ func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}, wantTy *cty.
 	for _, variable := range r.tfconfig.Module.Variables {
 		variables[variable.Name] = variable.Default
 	}
-	workspace, success := os.LookupEnv("TERRAFORM_WORKSPACE")
+	workspace, success := os.LookupEnv("TF_WORKSPACE")
 	if !success {
 		workspace = "default"
 	}


### PR DESCRIPTION
This is just used in the test runner, but we may as well be consistent
with the variable used in terraform and mainline tflint.

As suggested here: https://github.com/terraform-linters/tflint-plugin-sdk/pull/99#discussion_r563246414
As per the docs here: https://www.terraform.io/docs/cli/config/environment-variables.html#tf_workspace

(This is a super minor change. No urgency at all, just cleaning stuff up.)