### PR TITLE
Pass only type to EvalExpr when passed detailed types

### DIFF
--- a/tflint/client/client.go
+++ b/tflint/client/client.go
@@ -246,7 +246,10 @@ func (c *Client) EvaluateExpr(expr hcl.Expression, ret interface{}, wantType *ct
 	}
 
 	var response EvalExprResponse
-	req := EvalExprRequest{Ret: ret, Type: *wantType}
+	req := EvalExprRequest{Type: *wantType}
+	if req.Type == (cty.Type{}) {
+		req.Ret = ret
+	}
 	req.Expr, req.ExprRange = encodeExpr(file.Bytes, expr)
 	if err := c.rpcClient.Call("Plugin.EvalExpr", req, &response); err != nil {
 		return err
@@ -285,7 +288,10 @@ func (c *Client) EvaluateExprOnRootCtx(expr hcl.Expression, ret interface{}, wan
 	}
 
 	var response EvalExprResponse
-	req := EvalExprRequest{Ret: ret, Type: *wantType}
+	req := EvalExprRequest{Type: *wantType}
+	if req.Type == (cty.Type{}) {
+		req.Ret = ret
+	}
 	req.Expr, req.ExprRange = encodeExpr(file.Bytes, expr)
 	if err := c.rpcClient.Call("Plugin.EvalExprOnRootCtx", req, &response); err != nil {
 		return err


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-aws/issues/48
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/83

In #83, EvalExpr can now accept a type. If the type is passed, the object that reflects the evaluated result does not need to be sent to the server.

For instance, cty-based evaluation requires passing a complex object, which can cause gob encoding errors. This PR prevents the object from being included in the request when a detailed type is passed.

