### PR TITLE
tflint: Add workaround when parsing a config that has a trailing heredoc

### DIFF
--- a/tflint/config.go
+++ b/tflint/config.go
@@ -29,7 +29,10 @@ type MarshalledConfig struct {
 
 // Unmarshal converts intermediate representations into the Config object.
 func (c *MarshalledConfig) Unmarshal() (*Config, error) {
-	file, diags := hclsyntax.ParseConfig(c.BodyBytes, c.BodyRange.Filename, c.BodyRange.Start)
+	// HACK: Always add a newline to avoid heredoc parse errors.
+	// @see https://github.com/hashicorp/hcl/issues/441
+	src := []byte(string(c.BodyBytes) + "\n")
+	file, diags := hclsyntax.ParseConfig(src, c.BodyRange.Filename, c.BodyRange.Start)
 	if diags.HasErrors() {
 		return nil, diags
 	}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-plugin-sdk/issues/127
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/93

If a `plugin` block ends with a heredoc (e.g. `signing_key`), the heredoc will not contain a trailing newline when the plugin side process parses the configuration. This does not meet the grammar of the heredoc and results in an "Unterminated template string" error.

As with https://github.com/terraform-linters/tflint-plugin-sdk/pull/93, `Unmarshal` always adds a trailing newline when parsing the body. However, this is a pretty bad workaround. The biggest difference from https://github.com/terraform-linters/tflint-plugin-sdk/pull/93 is that the added newline is meaningful. When parsing an expression, newlines are always ignored and do not affect the final parsed result, but when parsing a body the number of newlines does affect the result. For example:

```hcl
plugin "aws" {
  foo = "bar"
  bar = "baz"
}
```

The above will be parsed as the following:


```hcl
plugin "aws" {
  foo = "bar"
  bar = "baz"

}
```

This can have a strange effect on the display of the number of lines. However, the number of lines in a config file is only displayed when occurs a parse error mainly, so I will ignore this problem and fix the bug here.