### PR TITLE
Allow WalkResources to walk all resources (of all types) if resourceType not specified

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -114,7 +114,7 @@ func (r *Runner) WalkResourceBlocks(resourceType, blockType string, walker func(
 // WalkResources visits all specified resources from Files.
 func (r *Runner) WalkResources(resourceType string, walker func(*configs.Resource) error) error {
 	for _, resource := range r.tfconfig.Module.ManagedResources {
-		if resource.Type != resourceType {
+		if resourceType != "" && resource.Type != resourceType {
 			continue
 		}
 


### PR DESCRIPTION
Modifies the `WalkResources` function such that if `resourceType` is passed the string zero-value `""`, the function walks over all resources of all types.