### PR TITLE
helper: Fix panic when helper runner uses variables

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -194,7 +194,7 @@ func (r *Runner) EnsureNoError(err error, proc func() error) error {
 // NewLocalRunner initialises a new test runner.
 // Internal use only.
 func NewLocalRunner(files map[string]*hcl.File, issues Issues) *Runner {
-	return &Runner{files: map[string]*hcl.File{}, Issues: issues}
+	return &Runner{files: map[string]*hcl.File{}, variables: map[string]*Variable{}, Issues: issues}
 }
 
 // AddLocalFile adds a new file to the current mapped files.


### PR DESCRIPTION
It panics when you use `helper.Runner` with variables. This PR fixes this issue.