### PR TITLE
Skip un-used `variable` block attributes

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -238,7 +238,7 @@ func decodeVariableBlock(block *hcl.Block) (*Variable, hcl.Diagnostics) {
 		DeclRange: block.DefRange,
 	}
 
-	content, diags := block.Body.Content(&hcl.BodySchema{
+	content, _, diags := block.Body.PartialContent(&hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
 			{
 				Name: "default",

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -265,6 +265,7 @@ resource "aws_instance" "foo" {
 			Name: "string interpolation",
 			Src: `
 variable "instance_type" {
+	type = string
   default = "t2.micro"
 }
 


### PR DESCRIPTION
When calling `helper.TestRunner`, `variable` blocks with any attribute other than `default` will trigger a parsing error. The runner needs to read the `default` and other attributes should silently pass through. Currently, they cause a panic.

With the modified test:

```
--- FAIL: Test_EvaluateExpr (0.00s)
    --- FAIL: Test_EvaluateExpr/string_interpolation (0.00s)
panic: Failed to initialize runner: main.tf:3,2-6: Unsupported argument; An argument named "type" is not expected here. [recovered]
	panic: Failed to initialize runner: main.tf:3,2-6: Unsupported argument; An argument named "type" is not expected here.

goroutine 6 [running]:
testing.tRunner.func1.2({0x12fb300, 0xc000049e20})
	/usr/local/Cellar/go/1.18/libexec/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/usr/local/Cellar/go/1.18/libexec/src/testing/testing.go:1392 +0x39f
panic({0x12fb300, 0xc000049e20})
	/usr/local/Cellar/go/1.18/libexec/src/runtime/panic.go:838 +0x207
github.com/terraform-linters/tflint-plugin-sdk/helper.TestRunner(0xc0001096c0, 0xc000067e20?)
	/Users/ben/src/terraform-linters/tflint-plugin-sdk/helper/testing.go:40 +0x394
github.com/terraform-linters/tflint-plugin-sdk/helper.Test_EvaluateExpr.func1(0xc0001096c0)
	/Users/ben/src/terraform-linters/tflint-plugin-sdk/helper/runner_test.go:281 +0x105
testing.tRunner(0xc0001096c0, 0xc000049d50)
	/usr/local/Cellar/go/1.18/libexec/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/usr/local/Cellar/go/1.18/libexec/src/testing/testing.go:1486 +0x35f
FAIL	github.com/terraform-linters/tflint-plugin-sdk/helper	0.137s
FAIL
```

Using `PartialContent` rather than `Content` resolves the failed test.

Closes #152 