### PR TITLE
plugin2host: Return sources instead of *hcl.File in GetRuleConfigContent

### DIFF
--- a/plugin/host2plugin/host2plugin_test.go
+++ b/plugin/host2plugin/host2plugin_test.go
@@ -474,8 +474,8 @@ func (s *mockServer) GetFile(filename string) (*hcl.File, error) {
 	return nil, nil
 }
 
-func (s *mockServer) GetRuleConfigContent(name string, schema *hclext.BodySchema) (*hclext.BodyContent, *hcl.File, error) {
-	return &hclext.BodyContent{}, &hcl.File{}, nil
+func (s *mockServer) GetRuleConfigContent(name string, schema *hclext.BodySchema) (*hclext.BodyContent, map[string][]byte, error) {
+	return &hclext.BodyContent{}, map[string][]byte{}, nil
 }
 
 func (s *mockServer) EvaluateExpr(expr hcl.Expression, opts tflint.EvaluateExprOption) (cty.Value, error) {


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1365

This PR changes the value for encoding returned by `GetRuleConfigContent` from `*hcl.File` to `map[string][]bytes`. This change is a host-side change and has no impact on plugins.