### PR TITLE
Add GetProviderContent helper

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -91,6 +91,29 @@ func (r *Runner) GetResourceContent(name string, schema *hclext.BodySchema, opts
 	return content, nil
 }
 
+// GetProviderContent gets a provider content of the current module
+func (r *Runner) GetProviderContent(name string, schema *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
+	body, err := r.GetModuleContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{Type: "provider", LabelNames: []string{"name"}, Body: schema},
+		},
+	}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	content := &hclext.BodyContent{Blocks: []*hclext.Block{}}
+	for _, provider := range body.Blocks {
+		if provider.Labels[0] != name {
+			continue
+		}
+
+		content.Blocks = append(content.Blocks, provider)
+	}
+
+	return content, nil
+}
+
 // GetFile returns the hcl.File object
 func (r *Runner) GetFile(filename string) (*hcl.File, error) {
 	return r.files[filename], nil

--- a/plugin/plugin2host/client.go
+++ b/plugin/plugin2host/client.go
@@ -66,6 +66,34 @@ func (c *GRPCClient) GetResourceContent(name string, inner *hclext.BodySchema, o
 	return content, nil
 }
 
+// GetProviderContent gets the contents of providers based on the schema.
+// This is shorthand of GetModuleContent for providers
+func (c *GRPCClient) GetProviderContent(name string, inner *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
+	if opts == nil {
+		opts = &tflint.GetModuleContentOption{}
+	}
+
+	body, err := c.GetModuleContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{Type: "provider", LabelNames: []string{"name"}, Body: inner},
+		},
+	}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	content := &hclext.BodyContent{Blocks: []*hclext.Block{}}
+	for _, provider := range body.Blocks {
+		if provider.Labels[0] != name {
+			continue
+		}
+
+		content.Blocks = append(content.Blocks, provider)
+	}
+
+	return content, nil
+}
+
 // GetModuleContent gets the contents of the module based on the schema.
 func (c *GRPCClient) GetModuleContent(schema *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
 	if opts == nil {

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -91,8 +91,12 @@ type Runner interface {
 	// ```
 	GetResourceContent(resourceName string, schema *hclext.BodySchema, option *GetModuleContentOption) (*hclext.BodyContent, error)
 
+	// GetProviderContent retrieves the content of providers based on the passed schema.
+	// This method is GetResourceContent for providers.
+	GetProviderContent(providerName string, schema *hclext.BodySchema, option *GetModuleContentOption) (*hclext.BodyContent, error)
+
 	// GetModuleContent retrieves the content of the module based on the passed schema.
-	// GetResourceContent is syntactic sugar for GetModuleContent, which you can use to access structures other than resources.
+	// GetResourceContent/GetProviderContent are syntactic sugar for GetModuleContent, which you can use to access other structures.
 	GetModuleContent(schema *hclext.BodySchema, option *GetModuleContentOption) (*hclext.BodyContent, error)
 
 	// GetFile returns the hcl.File object.


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-plugin-sdk/issues/167

This PR adds `GetProviderContent` method to Runner. This is the same as `GetResourceContent` for providers, and is internally syntactic sugar for `GetModuleContent`.