### PR TITLE
go 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: Run test
       run: go test ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: Run linters
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ NOTE: This plugin system is experimental. This means that API compatibility is f
 ## Requirements
 
 - TFLint v0.35+
-- Go v1.18
+- Go v1.19
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint-plugin-sdk
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.8


### PR DESCRIPTION
`gsed -i 's/1\.18/1.19/' .github/workflows/* README.md go.mod tools/go.mod`

go 1.18: https://github.com/terraform-linters/tflint-ruleset-aws/pull/314, https://github.com/terraform-linters/tflint-ruleset-azurerm/pull/154, https://github.com/terraform-linters/tflint-ruleset-google/pull/154, https://github.com/terraform-linters/tflint-ruleset-template/pull/47, https://github.com/terraform-linters/tflint-plugin-sdk/pull/145

go 1.19: https://github.com/terraform-linters/tflint-ruleset-aws/pull/359, https://github.com/terraform-linters/tflint-ruleset-azurerm/pull/185, https://github.com/terraform-linters/tflint-ruleset-google/pull/199, https://github.com/terraform-linters/tflint-ruleset-template/pull/59, https://github.com/terraform-linters/tflint-plugin-sdk/pull/176