### PR TITLE
helper: Add support for JSON syntax in TestRunner

### DIFF
--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -247,6 +247,39 @@ terraform {
 	}
 }
 
+func Test_GetModuleContent_json(t *testing.T) {
+	files := map[string]string{
+		"main.tf.json": `{"variable": {"foo": {"type": "string"}}}`,
+	}
+
+	runner := TestRunner(t, files)
+
+	schema := &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type: "variable",
+				Body: &hclext.BodySchema{
+					Blocks: []hclext.BlockSchema{
+						{
+							Type:       "type",
+							LabelNames: []string{"name"},
+							Body:       &hclext.BodySchema{},
+						},
+					},
+				},
+			},
+		},
+	}
+	got, err := runner.GetModuleContent(schema, nil)
+	if err != nil {
+		t.Error(err)
+	} else {
+		if len(got.Blocks) != 1 {
+			t.Errorf("got %d blocks, but 1 block is expected", len(got.Blocks))
+		}
+	}
+}
+
 func Test_EvaluateExpr(t *testing.T) {
 	tests := []struct {
 		Name string

--- a/helper/testing.go
+++ b/helper/testing.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -20,7 +21,13 @@ func TestRunner(t *testing.T, files map[string]string) *Runner {
 	parser := hclparse.NewParser()
 
 	for name, src := range files {
-		file, diags := parser.ParseHCL([]byte(src), name)
+		var file *hcl.File
+		var diags hcl.Diagnostics
+		if strings.HasSuffix(name, ".json") {
+			file, diags = parser.ParseJSON([]byte(src), name)
+		} else {
+			file, diags = parser.ParseHCL([]byte(src), name)
+		}
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}


### PR DESCRIPTION
Currently, the `TestRunner` accepts only native HCL syntax files. This PR adds support for JSON syntax files.

If it contains files with filenames ending in `.json`, parse the files with `ParseJSON` instead of `ParseHCL`.