### PR TITLE
Bump protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ NOTE: This plugin system is experimental. This means that API compatibility is f
 
 ## Requirements
 
-- TFLint v0.35+
+- TFLint v0.40+
 - Go v1.19
 
 ## Usage

--- a/plugin/host2plugin/plugin.go
+++ b/plugin/host2plugin/plugin.go
@@ -11,7 +11,7 @@ import (
 
 // handShakeConfig is used for UX. ProcotolVersion will be updated by incompatible changes.
 var handshakeConfig = plugin.HandshakeConfig{
-	ProtocolVersion:  10,
+	ProtocolVersion:  11,
 	MagicCookieKey:   "TFLINT_RULESET_PLUGIN",
 	MagicCookieValue: "5adSn1bX8nrDfgBqiAqqEkC6OE1h3iD8SqbMc5UUONx8x3xCF0KlPDsBRNDjoYDP",
 }


### PR DESCRIPTION
The next version, v0.12, will bump the protocol version. This means that all plugins will need to be rebuilt with the latest SDK in order to work with the upcoming TFLint v0.40+ release.