### PR TITLE
logger: Do not set location offset in go-plugin

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,6 +6,12 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// internalLogger is intended to be called via the public methods of the package.
+// So the output line will be the caller of this package.
+var internalLogger hclog.Logger
+
+// logger is inteded to be called directly.
+// It is mainly assumed to be used by go-plugin.
 var logger hclog.Logger
 
 // Use the init process to set the global logger.
@@ -18,56 +24,62 @@ func init() {
 		level = "off"
 	}
 
-	logger = hclog.New(&hclog.LoggerOptions{
+	internalLogger = hclog.New(&hclog.LoggerOptions{
 		Level:                    hclog.LevelFromString(level),
 		Output:                   os.Stderr,
 		TimeFormat:               "15:04:05",
 		IncludeLocation:          true,
 		AdditionalLocationOffset: 1,
 	})
+	logger = hclog.New(&hclog.LoggerOptions{
+		Level:           hclog.LevelFromString(level),
+		Output:          os.Stderr,
+		TimeFormat:      "15:04:05",
+		IncludeLocation: true,
+	})
 }
 
-// Logger returns hcl.Logger as it is
+// Logger returns hcl.Logger
 func Logger() hclog.Logger {
 	return logger
 }
 
 // Trace emits a message at the TRACE level
 func Trace(msg string, args ...interface{}) {
-	if logger == nil {
+	if internalLogger == nil {
 		return
 	}
-	logger.Trace(msg, args...)
+	internalLogger.Trace(msg, args...)
 }
 
 // Debug emits a message at the DEBUG level
 func Debug(msg string, args ...interface{}) {
-	if logger == nil {
+	if internalLogger == nil {
 		return
 	}
-	logger.Debug(msg, args...)
+	internalLogger.Debug(msg, args...)
 }
 
 // Info emits a message at the INFO level
 func Info(msg string, args ...interface{}) {
-	if logger == nil {
+	if internalLogger == nil {
 		return
 	}
-	logger.Info(msg, args...)
+	internalLogger.Info(msg, args...)
 }
 
 // Warn emits a message at the WARN level
 func Warn(msg string, args ...interface{}) {
-	if logger == nil {
+	if internalLogger == nil {
 		return
 	}
-	logger.Warn(msg, args...)
+	internalLogger.Warn(msg, args...)
 }
 
 // Error emits a message at the ERROR level
 func Error(msg string, args ...interface{}) {
-	if logger == nil {
+	if internalLogger == nil {
 		return
 	}
-	logger.Error(msg, args...)
+	internalLogger.Error(msg, args...)
 }


### PR DESCRIPTION
The log output includes the line number in an assembler, which is clearly wrong.

```
12:42:42 [WARN]  go-plugin@v1.4.5/client.go:355: plugin configured with a nil SecureConfig
12:42:42 [DEBUG] go-plugin@v1.4.5/client.go:355: starting plugin: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws args=["/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws"]
12:42:42 [DEBUG] go-plugin@v1.4.5/client.go:355: plugin started: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws pid=17795
12:42:42 [DEBUG] go-plugin@v1.4.5/client.go:355: waiting for RPC address: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws
12:42:42 [DEBUG] go-plugin@v1.4.5/client.go:355: using plugin: version=10
12:42:42 [DEBUG] runtime/asm_amd64.s:1594: tflint-ruleset-aws: 12:42:42 [DEBUG] host2plugin/server.go:38: plugin address: network=unix address=/tmp/plugin935001403
12:42:42 provider.go:64: [INFO] Prepare rules
12:42:42 provider.go:92: [INFO]   5 default rules enabled
12:42:42 [DEBUG] host2plugin/client.go:101: starting host-side gRPC server
12:42:42 [DEBUG] runtime/asm_amd64.s:1594: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
12:42:42 [INFO]  runtime/asm_amd64.s:1594: plugin process exited: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws pid=17795
12:42:42 [DEBUG] plugin/plugin.go:26: plugin exited
```

This is because the `hclog.Logger` passed to the go-plugin has an `AdditionalLocationOffset`. Do not set an offset here.
By removing the offset from the logger passed to go-plugin, you can output the correct log as follows:

```
12:38:45 [WARN]  go-plugin@v1.4.5/client.go:551: plugin configured with a nil SecureConfig
12:38:45 [DEBUG] go-plugin@v1.4.5/client.go:585: starting plugin: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws args=["/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws"]
12:38:45 [DEBUG] go-plugin@v1.4.5/client.go:593: plugin started: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws pid=16234
12:38:45 [DEBUG] go-plugin@v1.4.5/client.go:688: waiting for RPC address: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws
12:38:45 [DEBUG] go-plugin@v1.4.5/client.go:736: using plugin: version=10
12:38:45 [DEBUG] go-plugin@v1.4.5/client.go:1030: tflint-ruleset-aws: 12:38:45 [DEBUG] host2plugin/server.go:38: plugin address: network=unix address=/tmp/plugin849619141
12:38:45 provider.go:64: [INFO] Prepare rules
12:38:45 provider.go:92: [INFO]   5 default rules enabled
12:38:45 [DEBUG] host2plugin/client.go:101: starting host-side gRPC server
12:38:45 [DEBUG] go-plugin@v1.4.5/grpc_stdio.go:139: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
12:38:45 [INFO]  go-plugin@v1.4.5/client.go:646: plugin process exited: path=/home/codespace/.tflint.d/plugins/github.com/terraform-linters/tflint-ruleset-aws/0.16.1/tflint-ruleset-aws pid=16234
12:38:45 [DEBUG] go-plugin@v1.4.5/client.go:461: plugin exited
```