### PR TITLE
Allow a runner to be redefined within a ruleset

### DIFF
--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -64,8 +64,12 @@ type RuleSet interface {
 	// ```
 	ApplyConfig(*hclext.BodyContent) error
 
-	// Check runs inspection for each rule by applying Runner.
-	// This is a entrypoint for all inspections and can be used as a hook to inject a custom runner.
+	// NewRunner returns a new runner based on the original runner.
+	// Custom rulesets can override this method to inject a custom runner.
+	NewRunner(Runner) (Runner, error)
+
+	// Check is a entrypoint for all inspections.
+	// This is not supposed to be overridden from custom rulesets.
 	Check(Runner) error
 
 	// All Ruleset must embed the builtin ruleset.

--- a/tflint/ruleset.go
+++ b/tflint/ruleset.go
@@ -98,8 +98,19 @@ func (r *BuiltinRuleSet) ApplyConfig(content *hclext.BodyContent) error {
 	return nil
 }
 
+// NewRunner returns a new runner based on the original runner.
+// Custom rulesets can override this method to inject a custom runner.
+func (r *BuiltinRuleSet) NewRunner(runner Runner) (Runner, error) {
+	return runner, nil
+}
+
 // Check runs inspection for each rule by applying Runner.
 func (r *BuiltinRuleSet) Check(runner Runner) error {
+	runner, err := r.NewRunner(runner)
+	if err != nil {
+		return err
+	}
+
 	for _, rule := range r.EnabledRules {
 		if err := rule.Check(runner); err != nil {
 			return fmt.Errorf("Failed to check `%s` rule: %s", rule.Name(), err)


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-plugin-sdk/issues/191

Add a `NewRunner` function in RuleSet so that built-in rulesets always use this function. This allows custom rulesets to inject a custom runner by simply redefining the `NewRunner`. No need to redefine `Check`.