### PR TITLE
plugin2host: Handle eval errors on the client side

### DIFF
--- a/plugin/fromproto/fromproto.go
+++ b/plugin/fromproto/fromproto.go
@@ -307,9 +307,9 @@ func Error(err error) error {
 	case *proto.ErrorDetail:
 		switch t.Code {
 		case proto.ErrorCode_ERROR_CODE_UNKNOWN_VALUE:
-			return fmt.Errorf("%s%w", st.Message(), tflint.ErrUnknownValue)
+			return tflint.ErrUnknownValue
 		case proto.ErrorCode_ERROR_CODE_NULL_VALUE:
-			return fmt.Errorf("%s%w", st.Message(), tflint.ErrNullValue)
+			return tflint.ErrNullValue
 		case proto.ErrorCode_ERROR_CODE_UNEVALUABLE:
 			return fmt.Errorf("%s%w", st.Message(), tflint.ErrUnevaluable)
 		case proto.ErrorCode_ERROR_CODE_SENSITIVE:

--- a/plugin/host2plugin/plugin.go
+++ b/plugin/host2plugin/plugin.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SDKVersion is the SDK version.
-const SDKVersion = "0.15.0"
+const SDKVersion = "0.16.0"
 
 // handShakeConfig is used for UX. ProcotolVersion will be updated by incompatible changes.
 var handshakeConfig = plugin.HandshakeConfig{

--- a/plugin/plugin2host/plugin2host_test.go
+++ b/plugin/plugin2host/plugin2host_test.go
@@ -1745,6 +1745,116 @@ func TestEvaluateExpr(t *testing.T) {
 				return !errors.Is(err, tflint.ErrSensitive)
 			},
 		},
+		{
+			Name:       "unknown value",
+			Expr:       hclExpr(`var.foo`),
+			TargetType: reflect.TypeOf(""),
+			ServerImpl: func(expr hcl.Expression, opts tflint.EvaluateExprOption) (cty.Value, error) {
+				return evalExpr(expr, &hcl.EvalContext{
+					Variables: map[string]cty.Value{
+						"var": cty.MapVal(map[string]cty.Value{
+							"foo": cty.UnknownVal(cty.String),
+						}),
+					},
+				})
+			},
+			Want:        "",
+			GetFileImpl: fileExists,
+			ErrCheck: func(err error) bool {
+				return !errors.Is(err, tflint.ErrUnknownValue)
+			},
+		},
+		{
+			Name:       "unknown value as cty.Value",
+			Expr:       hclExpr(`var.foo`),
+			TargetType: reflect.TypeOf(cty.Value{}),
+			ServerImpl: func(expr hcl.Expression, opts tflint.EvaluateExprOption) (cty.Value, error) {
+				return evalExpr(expr, &hcl.EvalContext{
+					Variables: map[string]cty.Value{
+						"var": cty.MapVal(map[string]cty.Value{
+							"foo": cty.UnknownVal(cty.String),
+						}),
+					},
+				})
+			},
+			Want:        cty.UnknownVal(cty.String),
+			GetFileImpl: fileExists,
+			ErrCheck:    neverHappend,
+		},
+		{
+			Name:       "unknown value in object",
+			Expr:       hclExpr(`{ value = var.foo }`),
+			TargetType: reflect.TypeOf(map[string]string{}),
+			ServerImpl: func(expr hcl.Expression, opts tflint.EvaluateExprOption) (cty.Value, error) {
+				return evalExpr(expr, &hcl.EvalContext{
+					Variables: map[string]cty.Value{
+						"var": cty.MapVal(map[string]cty.Value{
+							"foo": cty.UnknownVal(cty.String),
+						}),
+					},
+				})
+			},
+			Want:        (map[string]string)(nil),
+			GetFileImpl: fileExists,
+			ErrCheck: func(err error) bool {
+				return !errors.Is(err, tflint.ErrUnknownValue)
+			},
+		},
+		{
+			Name:       "null",
+			Expr:       hclExpr(`var.foo`),
+			TargetType: reflect.TypeOf(""),
+			ServerImpl: func(expr hcl.Expression, opts tflint.EvaluateExprOption) (cty.Value, error) {
+				return evalExpr(expr, &hcl.EvalContext{
+					Variables: map[string]cty.Value{
+						"var": cty.MapVal(map[string]cty.Value{
+							"foo": cty.NullVal(cty.String),
+						}),
+					},
+				})
+			},
+			Want:        "",
+			GetFileImpl: fileExists,
+			ErrCheck: func(err error) bool {
+				return !errors.Is(err, tflint.ErrNullValue)
+			},
+		},
+		{
+			Name:       "null as cty.Value",
+			Expr:       hclExpr(`var.foo`),
+			TargetType: reflect.TypeOf(cty.Value{}),
+			ServerImpl: func(expr hcl.Expression, opts tflint.EvaluateExprOption) (cty.Value, error) {
+				return evalExpr(expr, &hcl.EvalContext{
+					Variables: map[string]cty.Value{
+						"var": cty.MapVal(map[string]cty.Value{
+							"foo": cty.NullVal(cty.String),
+						}),
+					},
+				})
+			},
+			Want:        cty.NullVal(cty.String),
+			GetFileImpl: fileExists,
+			ErrCheck:    neverHappend,
+		},
+		{
+			Name:       "null value in object",
+			Expr:       hclExpr(`{ value = var.foo }`),
+			TargetType: reflect.TypeOf(map[string]string{}),
+			ServerImpl: func(expr hcl.Expression, opts tflint.EvaluateExprOption) (cty.Value, error) {
+				return evalExpr(expr, &hcl.EvalContext{
+					Variables: map[string]cty.Value{
+						"var": cty.MapVal(map[string]cty.Value{
+							"foo": cty.NullVal(cty.String),
+						}),
+					},
+				})
+			},
+			Want:        (map[string]string)(nil),
+			GetFileImpl: fileExists,
+			ErrCheck: func(err error) bool {
+				return !errors.Is(err, tflint.ErrNullValue)
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -9,10 +9,11 @@ import (
 // inside the plugin system, so you usually don't have to worry about it.
 var (
 	// ErrUnknownValue is an error when an unknown value is referenced
-	ErrUnknownValue = errors.New("")
+	ErrUnknownValue = errors.New("unknown value found")
 	// ErrNullValue is an error when null value is referenced
-	ErrNullValue = errors.New("")
+	ErrNullValue = errors.New("null value found")
 	// ErrUnevaluable is an error when a received expression has unevaluable references.
+	// Deprecated: This error is no longer returned since TFLint v0.41.
 	ErrUnevaluable = errors.New("")
 	// ErrSensitive is an error when a received expression contains a sensitive value.
 	ErrSensitive = errors.New("")


### PR DESCRIPTION
For historical reasons, errors from evaluating unknown or NULL values were handled on the server side rather than on the client side.
https://github.com/terraform-linters/tflint/blob/v0.45.0/plugin/server.go#L143-L167

But given that `EvaluateExpr` is an endpoint that returns a `cty.Value`, it's preferable to handle this error on the client side.

This PR adds unknown and NULL value handling in `plugin2host.GRPCClient.EvaluateExpr`. Below are compatibility notes:

- Before TFLint v0.46
  - Both server-side and client-side are checked for errors. However, the added error is never returned as the error is always returned on the server side only.
- TFLint v0.46
  - An error is returned on the client side only.

For all host versions, conversion of errors on Protocol Buffers may not be necessary once the server side no longer returns errors, but is currently retained for compatibility reasons.