### PR TITLE
Add support for the bool type as a target value

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -260,14 +260,20 @@ func (r *Runner) evaluateExpr(expr hcl.Expression, target interface{}, opts *tfl
 			ty = cty.String
 		case *int:
 			ty = cty.Number
+		case *bool:
+			ty = cty.Bool
 		case *[]string:
 			ty = cty.List(cty.String)
 		case *[]int:
 			ty = cty.List(cty.Number)
+		case *[]bool:
+			ty = cty.List(cty.Bool)
 		case *map[string]string:
 			ty = cty.Map(cty.String)
 		case *map[string]int:
 			ty = cty.Map(cty.Number)
+		case *map[string]bool:
+			ty = cty.Map(cty.Bool)
 		case *cty.Value:
 			ty = cty.DynamicPseudoType
 		default:

--- a/plugin/plugin2host/client.go
+++ b/plugin/plugin2host/client.go
@@ -338,14 +338,20 @@ func (c *GRPCClient) evaluateExpr(expr hcl.Expression, target interface{}, opts 
 			ty = cty.String
 		case *int:
 			ty = cty.Number
+		case *bool:
+			ty = cty.Bool
 		case *[]string:
 			ty = cty.List(cty.String)
 		case *[]int:
 			ty = cty.List(cty.Number)
+		case *[]bool:
+			ty = cty.List(cty.Bool)
 		case *map[string]string:
 			ty = cty.Map(cty.String)
 		case *map[string]int:
 			ty = cty.Map(cty.Number)
+		case *map[string]bool:
+			ty = cty.Map(cty.Bool)
 		case *cty.Value:
 			ty = cty.DynamicPseudoType
 		default:

--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -190,9 +190,10 @@ type Runner interface {
 	//
 	// However, if the target is cty.Value, these errors will not be returned.
 	//
-	// Here are the types that can be passed as the target: string, int, []string, []int,
-	// map[string]string, map[string]int, and cty.Value. Passing any other type will
-	// result in a panic, but you can make an exception by passing wantType as an option.
+	// Here are the types that can be passed as the target: string, int, bool, []string,
+	// []int, []bool, map[string]string, map[string]int, map[string]bool, and cty.Value.
+	// Passing any other type will result in a panic, but you can make an exception by
+	// passing wantType as an option.
 	//
 	// ```
 	// type complexVal struct {


### PR DESCRIPTION
This PR changes `EvaluateExpr` to support the bool type as a target value. Previously the code below would error out as an unsupported target type:

```go
runner.EvaluateExpr(attr.Expr, func (enabled bool) error {
  // Test values
}, nil)
```

At the same time `[]bool` and `map[string]bool` are also supported.