### PR TITLE
Fix NewRunner hook not injecting a custom runner

### DIFF
--- a/plugin/host2plugin/server.go
+++ b/plugin/host2plugin/server.go
@@ -116,8 +116,11 @@ func (s *GRPCServer) Check(ctx context.Context, req *proto.Check_Request) (*prot
 	}
 	defer conn.Close()
 
-	err = s.impl.Check(&plugin2host.GRPCClient{Client: proto.NewRunnerClient(conn)})
-
+	runner, err := s.impl.NewRunner(&plugin2host.GRPCClient{Client: proto.NewRunnerClient(conn)})
+	if err != nil {
+		return nil, toproto.Error(codes.FailedPrecondition, err)
+	}
+	err = s.impl.Check(runner)
 	if err != nil {
 		return nil, toproto.Error(codes.Aborted, err)
 	}

--- a/tflint/ruleset.go
+++ b/tflint/ruleset.go
@@ -106,11 +106,6 @@ func (r *BuiltinRuleSet) NewRunner(runner Runner) (Runner, error) {
 
 // Check runs inspection for each rule by applying Runner.
 func (r *BuiltinRuleSet) Check(runner Runner) error {
-	runner, err := r.NewRunner(runner)
-	if err != nil {
-		return err
-	}
-
 	for _, rule := range r.EnabledRules {
 		if err := rule.Check(runner); err != nil {
 			return fmt.Errorf("Failed to check `%s` rule: %s", rule.Name(), err)


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-plugin-sdk/pull/225
See https://github.com/terraform-linters/tflint-ruleset-google/issues/265

If you call the `NewRunner` within the built-in ruleset, the `NewRunner` from the built-in ruleset will be called instead of the `NewRunner` defined in your custom ruleset. As a result, custom runners defined in custom rulesets will not be injected.

This PR fixes this bug by calling the `NewRunner` on the GRPC Server side instead of calling the `NewRunner` in the built-in ruleset.