### PR TITLE
tflint: Remove Check method from tflint.RuleSet interface

### DIFF
--- a/tflint/interface.go
+++ b/tflint/interface.go
@@ -68,9 +68,9 @@ type RuleSet interface {
 	// Custom rulesets can override this method to inject a custom runner.
 	NewRunner(Runner) (Runner, error)
 
-	// Check is a entrypoint for all inspections.
+	// BuiltinImpl returns the receiver itself as BuiltinRuleSet.
 	// This is not supposed to be overridden from custom rulesets.
-	Check(Runner) error
+	BuiltinImpl() *BuiltinRuleSet
 
 	// All Ruleset must embed the builtin ruleset.
 	mustEmbedBuiltinRuleSet()

--- a/tflint/ruleset.go
+++ b/tflint/ruleset.go
@@ -1,8 +1,6 @@
 package tflint
 
 import (
-	"fmt"
-
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/logger"
 )
@@ -104,14 +102,10 @@ func (r *BuiltinRuleSet) NewRunner(runner Runner) (Runner, error) {
 	return runner, nil
 }
 
-// Check runs inspection for each rule by applying Runner.
-func (r *BuiltinRuleSet) Check(runner Runner) error {
-	for _, rule := range r.EnabledRules {
-		if err := rule.Check(runner); err != nil {
-			return fmt.Errorf("Failed to check `%s` rule: %s", rule.Name(), err)
-		}
-	}
-	return nil
+// BuiltinImpl returns the receiver itself as BuiltinRuleSet.
+// This is not supposed to be overridden from custom rulesets.
+func (r *BuiltinRuleSet) BuiltinImpl() *BuiltinRuleSet {
+	return r
 }
 
 func (r *BuiltinRuleSet) mustEmbedBuiltinRuleSet() {}


### PR DESCRIPTION
This PR removes `Check` method from `tflint.RuleSet` interface. Instead, add a `BuiltinImpl` method and move the inspection implementation for all enabled rules to `host2plugin.GRPCServer`.

This change means completely dropping the extensibility of the `Check` method from custom rulesets. This is a breaking change, but since the `Check` method is not originally intended to be overridden by custom rulesets, the impact is minimal.