### PR TITLE
Un-export `NewLocalRunner` and `AddLocalFile`

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -350,9 +350,8 @@ func (r *Runner) EnsureNoError(err error, proc func() error) error {
 	return err
 }
 
-// NewLocalRunner initialises a new test runner.
-// Internal use only.
-func NewLocalRunner(files map[string]*hcl.File, issues Issues) *Runner {
+// newLocalRunner initialises a new test runner.
+func newLocalRunner(files map[string]*hcl.File, issues Issues) *Runner {
 	return &Runner{
 		files:     map[string]*hcl.File{},
 		sources:   map[string][]byte{},
@@ -361,9 +360,9 @@ func NewLocalRunner(files map[string]*hcl.File, issues Issues) *Runner {
 	}
 }
 
-// AddLocalFile adds a new file to the current mapped files.
-// Internal use only.
-func (r *Runner) AddLocalFile(name string, file *hcl.File) bool {
+// addLocalFile adds a new file to the current mapped files.
+// For testing only. Normally, the main TFLint process is responsible for loading files.
+func (r *Runner) addLocalFile(name string, file *hcl.File) bool {
 	if _, exists := r.files[name]; exists {
 		return false
 	}
@@ -373,6 +372,8 @@ func (r *Runner) AddLocalFile(name string, file *hcl.File) bool {
 	return true
 }
 
+// initFromFiles initializes the runner from locally added files.
+// For testing only.
 func (r *Runner) initFromFiles() error {
 	for _, file := range r.files {
 		content, _, diags := file.Body.PartialContent(configFileSchema)

--- a/helper/testing.go
+++ b/helper/testing.go
@@ -19,7 +19,7 @@ import (
 func TestRunner(t *testing.T, files map[string]string) *Runner {
 	t.Helper()
 
-	runner := NewLocalRunner(map[string]*hcl.File{}, Issues{})
+	runner := newLocalRunner(map[string]*hcl.File{}, Issues{})
 	parser := hclparse.NewParser()
 
 	for name, src := range files {
@@ -41,7 +41,7 @@ func TestRunner(t *testing.T, files map[string]string) *Runner {
 			}
 			runner.config = config
 		} else {
-			runner.AddLocalFile(name, file)
+			runner.addLocalFile(name, file)
 		}
 	}
 


### PR DESCRIPTION
In discussion of https://github.com/terraform-linters/tflint-ruleset-aws/pull/511, I noticed these two function are exported but labeled in their doc comment as "internal use only." I assumed this meant "we use this from other packages, but you shouldn't," which technically should be done in an `internal/` package to prevent external module callers.

But turns out that there isn't actually any usage outside the package:

https://github.com/search?q=org%3Aterraform-linters+NewLocalRunner&type=code
https://github.com/search?q=org%3Aterraform-linters+AddLocalFile&type=code

So to prevent any external use, I've un-exported these identifiers. Technically this is a breaking change but it shouldn't actually have any dependents.