### PR TITLE
hclext: Add support for expression unwrapping in hclext.BoundExpr

### DIFF
--- a/hclext/expression.go
+++ b/hclext/expression.go
@@ -45,3 +45,9 @@ func (e BoundExpr) Range() hcl.Range {
 func (e BoundExpr) StartRange() hcl.Range {
 	return e.original.StartRange()
 }
+
+// UnwrapExpression returns the original expression.
+// This satisfies the hcl.unwrapExpression interface.
+func (e BoundExpr) UnwrapExpression() hcl.Expression {
+	return e.original
+}


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-aws/issues/522#issuecomment-1647992363

This PR adds support for expression unwrapping in `hclext.BoundExpr`. `BoundExpr` implements the `UnwrapExpression` method, allowing `hcl.UnwrapExpression` to return the original expression.