### PR TITLE
feat: add check for .hcl file ext

### DIFF
--- a/plugin/internal/plugin2host/client.go
+++ b/plugin/internal/plugin2host/client.go
@@ -146,7 +146,7 @@ func (c *GRPCClient) GetFile(file string) (*hcl.File, error) {
 
 	var f *hcl.File
 	var diags hcl.Diagnostics
-	if strings.HasSuffix(file, ".tf") {
+	if strings.HasSuffix(file, ".tf") || strings.HasSuffix(file, ".hcl") {
 		f, diags = hclsyntax.ParseConfig(resp.File, file, hcl.InitialPos)
 	} else {
 		f, diags = hcljson.Parse(resp.File, file)
@@ -170,7 +170,7 @@ func (c *GRPCClient) GetFiles() (map[string]*hcl.File, error) {
 	var diags hcl.Diagnostics
 	for name, bytes := range resp.Files {
 		var d hcl.Diagnostics
-		if strings.HasSuffix(name, ".tf") {
+		if strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".hcl") {
 			f, d = hclsyntax.ParseConfig(bytes, name, hcl.InitialPos)
 		} else {
 			f, d = hcljson.Parse(bytes, name)


### PR DESCRIPTION
I am working on adding support of linting terragrunt.hcl files with tflint and without this patch tflint tries to parse .hcl files as json and fails