### PR TITLE
helper: Add support ephemeral variables in TestRunner

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -415,6 +415,9 @@ func decodeVariableBlock(block *hcl.Block) (*Variable, hcl.Diagnostics) {
 			{
 				Name: "sensitive",
 			},
+			{
+				Name: "ephemeral",
+			},
 		},
 	})
 	if diags.HasErrors() {
@@ -437,6 +440,15 @@ func decodeVariableBlock(block *hcl.Block) (*Variable, hcl.Diagnostics) {
 		}
 
 		v.Default = v.Default.Mark(marks.Sensitive)
+	}
+	if attr, exists := content.Attributes["ephemeral"]; exists {
+		var ephemeral bool
+		diags := gohcl.DecodeExpression(attr.Expr, nil, &ephemeral)
+		if diags.HasErrors() {
+			return v, diags
+		}
+
+		v.Default = v.Default.Mark(marks.Ephemeral)
 	}
 
 	return v, nil

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -622,6 +622,20 @@ resource "aws_instance" "foo" {
 }`,
 			Want: `cty.StringVal("secret").Mark(marks.Sensitive)`,
 		},
+		{
+			Name: "ephemeral variable",
+			Src: `
+variable "instance_type" {
+  type = string
+  default = "secret"
+  ephemeral = true
+}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: `cty.StringVal("secret").Mark(marks.Ephemeral)`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/358
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/337

This PR adds support for the `ephemeral` attribute on variable blocks, making it easier to test ephemeral values ​​like the following:

```hcl
variable "ephemeral" {
  default = "secret"
  ephemeral = true
}
```