### PR TITLE
Stop updating CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+See https://github.com/terraform-linters/tflint-plugin-sdk/releases for later releases.
+
 ## 0.22.0 (2025-01-11)
 
 ### Enhancements


### PR DESCRIPTION
See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

To take advantage of the auto-generated release notes, we will no longer update the CHANGELOG.md file included in the repository, but will add a link to the releases page.