### PR TITLE
Fix Update ParseExpression to parse any json passed to it.

### DIFF
--- a/hclext/parse.go
+++ b/hclext/parse.go
@@ -13,6 +13,7 @@ import (
 // This function specializes in parsing intermediate expressions in the file,
 // so it takes into account the hack on trailing newlines in heredoc.
 func ParseExpression(src []byte, filename string, start hcl.Pos) (hcl.Expression, hcl.Diagnostics) {
+	// Handle HCL files: .tf (Terraform HCL) and .hcl (HCL config like .tflint.hcl)
 	if strings.HasSuffix(filename, ".tf") || strings.HasSuffix(filename, ".hcl") {
 		// HACK: Always add a newline to avoid heredoc parse errors.
 		// @see https://github.com/hashicorp/hcl/issues/441
@@ -20,7 +21,11 @@ func ParseExpression(src []byte, filename string, start hcl.Pos) (hcl.Expression
 		return hclsyntax.ParseExpression(src, filename, start)
 	}
 
-	if strings.HasSuffix(filename, ".tf.json") {
+	// Handle JSON files:
+	// We accept any .json file (including .tf.json), not just specific ones like .tflint.json.
+	// The calling functions are responsible for validating that the file should be processed.
+	// If the content is not valid HCL-compatible JSON, the JSON parser will return appropriate diagnostics.
+	if strings.HasSuffix(filename, ".tf.json") || strings.HasSuffix(filename, ".json") {
 		return json.ParseExpressionWithStartPos(src, filename, start)
 	}
 
@@ -28,7 +33,7 @@ func ParseExpression(src []byte, filename string, start hcl.Pos) (hcl.Expression
 		{
 			Severity: hcl.DiagError,
 			Summary:  "Unexpected file extension",
-			Detail:   fmt.Sprintf("The file name `%s` is a file with an unexpected extension. Valid extensions are `.tf`, `.tf.json`, and `.hcl`.", filename),
+			Detail:   fmt.Sprintf("The file name `%s` is a file with an unexpected extension. Valid extensions are `.tf`, `.tf.json`, `.hcl`, and `.json`.", filename),
 		},
 	}
 }

--- a/hclext/parse_test.go
+++ b/hclext/parse_test.go
@@ -30,10 +30,18 @@ func TestParseExpression(t *testing.T) {
 			DiagCount: 0,
 		},
 		{
-			Name:      "HCL but file extension is invalid (*.json)",
+			Name:      "JSON (*.json)",
 			Source:    `"baz"`,
 			Filename:  "test.json",
-			DiagCount: 1,
+			Want:      `cty.StringVal("baz")`,
+			DiagCount: 0,
+		},
+		{
+			Name:      "JSON (.tflint.json)",
+			Source:    `{"config": {"force": true}}`,
+			Filename:  ".tflint.json",
+			Want:      `cty.ObjectVal(map[string]cty.Value{"config":cty.ObjectVal(map[string]cty.Value{"force":cty.True})})`,
+			DiagCount: 0,
 		},
 		{
 			Name: "HCL heredoc with trailing newline",
@@ -60,6 +68,18 @@ EOF`,
 			Filename:  "test.tf.json",
 			Want:      `cty.ObjectVal(map[string]cty.Value{"baz":cty.NumberIntVal(1), "foo":cty.StringVal("bar")})`,
 			DiagCount: 0,
+		},
+		{
+			Name:      "Invalid JSON content",
+			Source:    `{invalid json content}`,
+			Filename:  "test.json",
+			DiagCount: 2, // JSON parser returns 2 diagnostics for this invalid JSON
+		},
+		{
+			Name:      "Invalid file extension",
+			Source:    `"test"`,
+			Filename:  "test.yaml",
+			DiagCount: 1,
 		},
 	}
 


### PR DESCRIPTION
Updated ParseExpression to support parsing any json files in addition to the existing .tf, .tf.json, and .hcl file extensions.

## What changed?
  - Modified ParseExpression to accept any .json file extension, not just .tf.json
  - Updated error message to include .json as a valid extension
  - Added comments clarifying that calling functions are responsible for file validation
  - Added test cases for:
    - Regular .json files
    - .tflint.json configuration files
    - Invalid JSON content (verifies proper error handling)
    - Invalid file extensions

## Why make this change?

[TFLint](https://github.com/terraform-linters/tflint/issues/2389) is introducing the ability to define configuration as JSON (.tflint.json) in addition to HCL (.tflint.hcl). The ParseExpression function needs to support parsing these JSON configuration files.

There are only two callers of this function:

  1. **fromproto.Expression** - Receives expressions from both Terraform files AND TFLint config files (including .tflint.json), requiring .json support
  2. **getExprFromRange** in plugin/server.go - Only processes Terraform files (.tf and .tf.json) as these are the only files loaded into runner.TFConfig.Module.Files

The calling functions already validate that files are hcl and should be processed, and the JSON parser will return appropriate diagnostics if the content is not valid HCL-compatible JSON.

## Design Decision

I chose to accept any .json extension rather than specifically adding .tflint.json because:
  - The calling functions already perform appropriate file filtering
  - Users may name config files differently (e.g., --config=myconfig.json)
  - The JSON parser will properly reject invalid content with diagnostics

## Question for reviewers: 
Are we comfortable accepting any .json file at this level, or would you prefer we restrict to specific patterns like .tflint.json and restrict configuration inputs to only accept `.tflint.json` on the tflint server side?