### PR TITLE
dependabot: Set cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 5
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 5


### PR DESCRIPTION
To mitigate the risks posed by recent supply chain attacks, setting 5-day cooldown period for all package updates.