### PR TITLE
helper: Add support for unknown variables

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -431,6 +431,8 @@ func decodeVariableBlock(block *hcl.Block) (*Variable, hcl.Diagnostics) {
 		}
 
 		v.Default = val
+	} else {
+		v.Default = cty.DynamicVal
 	}
 	if attr, exists := content.Attributes["sensitive"]; exists {
 		var sensitive bool

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -609,6 +609,16 @@ func Test_EvaluateExpr_value(t *testing.T) {
 		Want string
 	}{
 		{
+			Name: "unknown variable",
+			Src: `
+variable "instance_type" {}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: `cty.DynamicVal`,
+		},
+		{
 			Name: "sensitive variable",
 			Src: `
 variable "instance_type" {


### PR DESCRIPTION
Previously, the test runner did not support evaluation of unknown values ​​(it would result in `cty.NilVal`), but this will now work.