### PR TITLE
terraform: Add support for parsing bare references

### DIFF
--- a/terraform/addrs/bare.go
+++ b/terraform/addrs/bare.go
@@ -1,0 +1,13 @@
+package addrs
+
+// BareRef is the address of a pseudo bare reference like `ignore_changes = [tags]`.
+// This is not a valid address in Terraform, but in the context of TFLint static analysis,
+// it may be preferable that any bare reference be parsable.
+type BareRef struct {
+	referenceable
+	Name string
+}
+
+func (br BareRef) String() string {
+	return br.Name
+}

--- a/terraform/addrs/parse_ref.go
+++ b/terraform/addrs/parse_ref.go
@@ -221,6 +221,16 @@ func parseRef(traversal hcl.Traversal) (*Reference, hcl.Diagnostics) {
 		return nil, diags
 
 	default:
+		// Bare references like `ignore_changes = [tags]` are invalid in Terraform,
+		// but they are returned as valid references in the context of static analysis.
+		if len(traversal) == 1 {
+			return &Reference{
+				Subject:     BareRef{Name: root},
+				SourceRange: rootRange,
+			}, diags
+		}
+
+		// Parse traversal except a bare reference, assuming this is a managed resource reference.
 		return parseResourceRef(ManagedResourceMode, rootRange, traversal)
 	}
 }

--- a/terraform/addrs/parse_ref_test.go
+++ b/terraform/addrs/parse_ref_test.go
@@ -712,8 +712,16 @@ func TestParseRef(t *testing.T) {
 		},
 		{
 			`boop_instance`,
-			nil,
-			`A reference to a resource type must be followed by at least one attribute access, specifying the resource name.`,
+			&Reference{
+				Subject: BareRef{
+					Name: "boop_instance",
+				},
+				SourceRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:   hcl.Pos{Line: 1, Column: 14, Byte: 13},
+				},
+			},
+			``,
 		},
 	}
 

--- a/terraform/lang/references_test.go
+++ b/terraform/lang/references_test.go
@@ -82,9 +82,18 @@ func TestReferencesInExpr(t *testing.T) {
 			},
 		},
 		{
-			Name:  "contains invalid references",
-			Input: `"${boop_instance}_${var.foo}"`, // A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
+			Name:  "contains bare references",
+			Input: `"${boop_instance}_${var.foo}"`,
 			Want: []*addrs.Reference{
+				{
+					Subject: addrs.BareRef{
+						Name: "boop_instance",
+					},
+					SourceRange: hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 4, Byte: 3},
+						End:   hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+				},
 				{
 					Subject: addrs.InputVariable{
 						Name: "foo",


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/issues/2435

In `terraform/lang.ReferencesInExpr`, bare references like `ignore_changes = [tags]` were not included as valid references.
`ReferencesInExpr` simply ignores it, while `References` returns the following error:

```
A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
```

This PR changes the functions so that such bare references are returned as valid references. This is different behavior from Terraform, but it is useful in TFLint, where arbitrary expressions may be parsed.