### PR TITLE
helper: Fix panic in GetModuleContent on top-level attributes

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -63,7 +63,10 @@ func (r *Runner) GetModulePath() (addrs.Module, error) {
 
 // GetModuleContent gets a content of the current module
 func (r *Runner) GetModuleContent(schema *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
-	content := &hclext.BodyContent{}
+	content := &hclext.BodyContent{
+		Attributes: hclext.Attributes{},
+		Blocks:     hclext.Blocks{},
+	}
 	diags := hcl.Diagnostics{}
 
 	for _, f := range r.files {

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -186,6 +186,7 @@ terraform {
 				},
 			},
 			Expected: &hclext.BodyContent{
+				Attributes: hclext.Attributes{},
 				Blocks: hclext.Blocks{
 					{
 						Type: "terraform",
@@ -225,6 +226,56 @@ terraform {
 						TypeRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2, Column: 1}, End: hcl.Pos{Line: 2, Column: 10}},
 					},
 				},
+			},
+		},
+		{
+			Name: "top level attribute",
+			Src:  `foo = "bar"`,
+			Schema: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo"}},
+			},
+			Expected: &hclext.BodyContent{
+				Attributes: hclext.Attributes{
+					"foo": &hclext.Attribute{
+						Name: "foo",
+						Expr: &hclsyntax.TemplateExpr{
+							Parts: []hclsyntax.Expression{
+								&hclsyntax.LiteralValueExpr{
+									SrcRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 8}, End: hcl.Pos{Line: 1, Column: 11}},
+								},
+							},
+							SrcRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 7}, End: hcl.Pos{Line: 1, Column: 12}},
+						},
+						Range:     hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 1}, End: hcl.Pos{Line: 1, Column: 12}},
+						NameRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 1}, End: hcl.Pos{Line: 1, Column: 4}},
+					},
+				},
+				Blocks: hclext.Blocks{},
+			},
+		},
+		{
+			Name: "just attributes mode",
+			Src:  `foo = "bar"`,
+			Schema: &hclext.BodySchema{
+				Mode: hclext.SchemaJustAttributesMode,
+			},
+			Expected: &hclext.BodyContent{
+				Attributes: hclext.Attributes{
+					"foo": &hclext.Attribute{
+						Name: "foo",
+						Expr: &hclsyntax.TemplateExpr{
+							Parts: []hclsyntax.Expression{
+								&hclsyntax.LiteralValueExpr{
+									SrcRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 8}, End: hcl.Pos{Line: 1, Column: 11}},
+								},
+							},
+							SrcRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 7}, End: hcl.Pos{Line: 1, Column: 12}},
+						},
+						Range:     hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 1}, End: hcl.Pos{Line: 1, Column: 12}},
+						NameRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 1, Column: 1}, End: hcl.Pos{Line: 1, Column: 4}},
+					},
+				},
+				Blocks: hclext.Blocks{},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes a panic in `helper.Runner.GetModuleContent` when a schema requests top-level attributes. The method built its result from a zero-value `hclext.BodyContent`, so assigning a matching attribute panicked with "assignment to entry in nil map". Initializes `Attributes` and `Blocks` up front, matching how `hclext` constructs `BodyContent`.

## Testing

Adds regression cases to `Test_GetModuleContent` covering a top-level attribute schema and `SchemaJustAttributesMode`, both of which panicked before the fix.
