### PR TITLE
helper: Only mark variables when sensitive/ephemeral is true

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -441,7 +441,9 @@ func decodeVariableBlock(block *hcl.Block) (*Variable, hcl.Diagnostics) {
 			return v, diags
 		}
 
-		v.Default = v.Default.Mark(marks.Sensitive)
+		if sensitive {
+			v.Default = v.Default.Mark(marks.Sensitive)
+		}
 	}
 	if attr, exists := content.Attributes["ephemeral"]; exists {
 		var ephemeral bool
@@ -450,7 +452,9 @@ func decodeVariableBlock(block *hcl.Block) (*Variable, hcl.Diagnostics) {
 			return v, diags
 		}
 
-		v.Default = v.Default.Mark(marks.Ephemeral)
+		if ephemeral {
+			v.Default = v.Default.Mark(marks.Ephemeral)
+		}
 	}
 
 	return v, nil

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -633,6 +633,20 @@ resource "aws_instance" "foo" {
 			Want: `cty.StringVal("secret").Mark(marks.Sensitive)`,
 		},
 		{
+			Name: "explicitly non-sensitive variable",
+			Src: `
+variable "instance_type" {
+  type = string
+  default = "t2.micro"
+  sensitive = false
+}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: `cty.StringVal("t2.micro")`,
+		},
+		{
 			Name: "ephemeral variable",
 			Src: `
 variable "instance_type" {
@@ -645,6 +659,20 @@ resource "aws_instance" "foo" {
   instance_type = var.instance_type
 }`,
 			Want: `cty.StringVal("secret").Mark(marks.Ephemeral)`,
+		},
+		{
+			Name: "explicitly non-ephemeral variable",
+			Src: `
+variable "instance_type" {
+  type = string
+  default = "t2.micro"
+  ephemeral = false
+}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: `cty.StringVal("t2.micro")`,
 		},
 	}
 


### PR DESCRIPTION
Fixes `decodeVariableBlock` marking a variable's default value based on the presence of the `sensitive` and `ephemeral` attributes rather than their decoded values. A variable declaring `sensitive = false` or `ephemeral = false` was incorrectly marked, so `EvaluateExpr` treated it as sensitive or ephemeral.

## Testing

Adds `Test_EvaluateExpr` cases for explicitly non-sensitive and non-ephemeral variables, asserting the evaluated value carries no marks.
