### PR TITLE
helper: Return sentinel errors for unknown/null/marked values

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -238,7 +238,11 @@ func (r *Runner) EvaluateExpr(expr hcl.Expression, target interface{}, opts *tfl
 
 	if err != nil {
 		// If it cannot be represented as a Go value, exit without invoking the callback rather than returning an error.
-		if errors.Is(err, tflint.ErrUnknownValue) || errors.Is(err, tflint.ErrNullValue) || errors.Is(err, tflint.ErrSensitive) || errors.Is(err, tflint.ErrUnevaluable) {
+		if errors.Is(err, tflint.ErrUnknownValue) ||
+			errors.Is(err, tflint.ErrNullValue) ||
+			errors.Is(err, tflint.ErrSensitive) ||
+			errors.Is(err, tflint.ErrEphemeral) ||
+			errors.Is(err, tflint.ErrUnevaluable) {
 			return nil
 		}
 		return err
@@ -310,6 +314,31 @@ func (r *Runner) evaluateExpr(expr hcl.Expression, target interface{}, opts *tfl
 		return err
 	}
 
+	if ty == cty.DynamicPseudoType {
+		return gocty.FromCtyValue(val, target)
+	}
+
+	// Returns an error if the value cannot be decoded to a Go value (e.g. unknown, null, marked).
+	// This allows the caller to handle the value by the errors package.
+	err = cty.Walk(val, func(path cty.Path, v cty.Value) (bool, error) {
+		if !v.IsKnown() {
+			return false, tflint.ErrUnknownValue
+		}
+		if v.IsNull() {
+			return false, tflint.ErrNullValue
+		}
+		if v.HasMark(marks.Sensitive) {
+			return false, tflint.ErrSensitive
+		}
+		if v.HasMark(marks.Ephemeral) {
+			return false, tflint.ErrEphemeral
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
 	return gocty.FromCtyValue(val, target)
 }
 
@@ -348,6 +377,10 @@ func (r *Runner) Changes() map[string][]byte {
 func (r *Runner) EnsureNoError(err error, proc func() error) error {
 	if err == nil {
 		return proc()
+	}
+
+	if errors.Is(err, tflint.ErrUnevaluable) || errors.Is(err, tflint.ErrNullValue) || errors.Is(err, tflint.ErrUnknownValue) || errors.Is(err, tflint.ErrSensitive) {
+		return nil
 	}
 	return err
 }

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -684,6 +684,106 @@ resource "aws_instance" "foo" {
 	}
 }
 
+func Test_EvaluateExpr_sentinels(t *testing.T) {
+	tests := []struct {
+		Name string
+		Src  string
+		Want error
+	}{
+		{
+			Name: "known value",
+			Src: `
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}`,
+			Want: nil,
+		},
+		{
+			Name: "sensitive variable",
+			Src: `
+variable "instance_type" {
+  default   = "secret"
+  sensitive = true
+}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: tflint.ErrSensitive,
+		},
+		{
+			Name: "ephemeral variable",
+			Src: `
+variable "instance_type" {
+  default   = "secret"
+  ephemeral = true
+}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: tflint.ErrEphemeral,
+		},
+		{
+			Name: "unknown variable",
+			Src: `
+variable "instance_type" {}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: tflint.ErrUnknownValue,
+		},
+		{
+			Name: "null variable",
+			Src: `
+variable "instance_type" {
+  default = null
+}
+
+resource "aws_instance" "foo" {
+  instance_type = var.instance_type
+}`,
+			Want: tflint.ErrNullValue,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runner := TestRunner(t, map[string]string{"main.tf": test.Src})
+
+			resources, err := runner.GetResourceContent("aws_instance", &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "instance_type"}},
+			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, resource := range resources.Blocks {
+				// raw value
+				var instanceType string
+				err := runner.EvaluateExpr(resource.Body.Attributes["instance_type"].Expr, &instanceType, nil)
+				if !errors.Is(err, test.Want) {
+					t.Fatalf("expected %v, but got %v", test.Want, err)
+				}
+
+				// callback: sentinel errors are filtered without invoking the callback
+				called := false
+				err = runner.EvaluateExpr(resource.Body.Attributes["instance_type"].Expr, func(val string) error {
+					called = true
+					return nil
+				}, nil)
+				if err != nil {
+					t.Fatalf("expected no error, but got %v", err)
+				}
+				if wantCalled := test.Want == nil; called != wantCalled {
+					t.Fatalf("expected callback invocation to be %t, but got %t", wantCalled, called)
+				}
+			}
+		})
+	}
+}
+
 type dummyRule struct {
 	tflint.DefaultRule
 }
@@ -910,18 +1010,77 @@ locals {
 }
 
 func Test_EnsureNoError(t *testing.T) {
-	runner := TestRunner(t, map[string]string{})
-
-	var run bool
-	err := runner.EnsureNoError(nil, func() error {
-		run = true
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		Name    string
+		Err     error
+		WantErr error
+		WantRun bool
+	}{
+		{
+			Name:    "no error",
+			Err:     nil,
+			WantErr: nil,
+			WantRun: true,
+		},
+		{
+			Name:    "unevaluable error",
+			Err:     tflint.ErrUnevaluable,
+			WantErr: nil,
+			WantRun: false,
+		},
+		{
+			Name:    "null value error",
+			Err:     tflint.ErrNullValue,
+			WantErr: nil,
+			WantRun: false,
+		},
+		{
+			Name:    "unknown value error",
+			Err:     tflint.ErrUnknownValue,
+			WantErr: nil,
+			WantRun: false,
+		},
+		{
+			Name:    "sensitive error",
+			Err:     tflint.ErrSensitive,
+			WantErr: nil,
+			WantRun: false,
+		},
+		{
+			// The production runner does not filter ErrEphemeral in EnsureNoError.
+			Name:    "ephemeral error",
+			Err:     tflint.ErrEphemeral,
+			WantErr: tflint.ErrEphemeral,
+			WantRun: false,
+		},
+		{
+			Name:    "other error",
+			Err:     errors.New("unexpected"),
+			WantErr: errors.New("unexpected"),
+			WantRun: false,
+		},
 	}
 
-	if !run {
-		t.Fatal("Expected to exec the passed proc, but doesn't")
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runner := TestRunner(t, map[string]string{})
+
+			var run bool
+			err := runner.EnsureNoError(test.Err, func() error {
+				run = true
+				return nil
+			})
+			if test.WantErr == nil {
+				if err != nil {
+					t.Fatalf("expected no error, but got %v", err)
+				}
+			} else if err == nil || err.Error() != test.WantErr.Error() {
+				t.Fatalf("expected %v, but got %v", test.WantErr, err)
+			}
+
+			if run != test.WantRun {
+				t.Fatalf("expected proc invocation to be %t, but got %t", test.WantRun, run)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Ports the production runner's post-evaluation value check (`plugin2host.GRPCClient.evaluateExpr`) to `helper.Runner.EvaluateExpr`. Before this change the helper diverged from production in three ways:

- Evaluating a sensitive or ephemeral value into a Go-typed target panicked in `gocty.FromCtyValue` ("value is marked, so must be unmarked first") instead of returning `tflint.ErrSensitive` / `tflint.ErrEphemeral`.
- Unknown and null values returned raw `gocty` errors instead of `tflint.ErrUnknownValue` / `tflint.ErrNullValue`, so the callback ignore list never matched and callbacks received errors production silently skips.
- The callback ignore list omitted `tflint.ErrEphemeral`, and `EnsureNoError` returned sentinel errors instead of filtering them.

Like the production runner, the check is skipped for `cty.DynamicPseudoType` targets, so `*cty.Value` targets still receive marked and unknown values unchanged.

This is a behavior change for plugin test suites: `EvaluateExpr` now returns `tflint.Err*` sentinel errors where it previously panicked or returned `gocty` error strings. Tests matching on the old error text may need updates, but the new behavior matches what plugins see in production.

## Testing

Adds `Test_EvaluateExpr_sentinels` covering known, sensitive, ephemeral, unknown, and null values through both pointer targets (sentinel errors returned) and callbacks (sentinels filtered, callback not invoked). Extends `Test_EnsureNoError` with sentinel filtering cases.
