### PR TITLE
Extract shared Runner front-end into internal/runner

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -2,21 +2,19 @@ package helper
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"reflect"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/internal"
+	"github.com/terraform-linters/tflint-plugin-sdk/internal/runner"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/addrs"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/lang/marks"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
-	"github.com/zclconf/go-cty/cty/gocty"
 )
 
 // Runner is a mock that satisfies the Runner interface for plugin testing.
@@ -86,48 +84,12 @@ func (r *Runner) GetModuleContent(schema *hclext.BodySchema, opts *tflint.GetMod
 
 // GetResourceContent gets a resource content of the current module
 func (r *Runner) GetResourceContent(name string, schema *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
-	body, err := r.GetModuleContent(&hclext.BodySchema{
-		Blocks: []hclext.BlockSchema{
-			{Type: "resource", LabelNames: []string{"type", "name"}, Body: schema},
-		},
-	}, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	content := &hclext.BodyContent{Blocks: []*hclext.Block{}}
-	for _, resource := range body.Blocks {
-		if resource.Labels[0] != name {
-			continue
-		}
-
-		content.Blocks = append(content.Blocks, resource)
-	}
-
-	return content, nil
+	return runner.GetResourceContent(r, name, schema, opts)
 }
 
 // GetProviderContent gets a provider content of the current module
 func (r *Runner) GetProviderContent(name string, schema *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
-	body, err := r.GetModuleContent(&hclext.BodySchema{
-		Blocks: []hclext.BlockSchema{
-			{Type: "provider", LabelNames: []string{"name"}, Body: schema},
-		},
-	}, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	content := &hclext.BodyContent{Blocks: []*hclext.Block{}}
-	for _, provider := range body.Blocks {
-		if provider.Labels[0] != name {
-			continue
-		}
-
-		content.Blocks = append(content.Blocks, provider)
-	}
-
-	return content, nil
+	return runner.GetProviderContent(r, name, schema, opts)
 }
 
 // GetFile returns the hcl.File object
@@ -188,110 +150,28 @@ func (r *Runner) WalkExpressions(walker tflint.ExprWalker) hcl.Diagnostics {
 
 // DecodeRuleConfig extracts the rule's configuration into the given value
 func (r *Runner) DecodeRuleConfig(name string, ret interface{}) error {
-	schema := hclext.ImpliedBodySchema(ret)
-
-	for _, rule := range r.config.Rules {
-		if rule.Name == name {
-			body, diags := hclext.Content(rule.Body, schema)
-			if diags.HasErrors() {
-				return diags
+	return runner.DecodeRuleConfig(ret, func(schema *hclext.BodySchema) (*hclext.BodyContent, error) {
+		for _, rule := range r.config.Rules {
+			if rule.Name == name {
+				body, diags := hclext.Content(rule.Body, schema)
+				if diags.HasErrors() {
+					return nil, diags
+				}
+				return body, nil
 			}
-			if diags := hclext.DecodeBody(body, nil, ret); diags.HasErrors() {
-				return diags
-			}
-			return nil
 		}
-	}
-
-	return nil
+		return nil, nil
+	})
 }
-
-var errRefTy = reflect.TypeOf((*error)(nil)).Elem()
 
 // EvaluateExpr returns a value of the passed expression.
 // Note that some features are limited
 func (r *Runner) EvaluateExpr(expr hcl.Expression, target interface{}, opts *tflint.EvaluateExprOption) error {
-	rval := reflect.ValueOf(target)
-	rty := rval.Type()
-
-	var callback bool
-	switch rty.Kind() {
-	case reflect.Func:
-		// Callback must meet the following requirements:
-		//   - It must be a function
-		//   - It must take an argument
-		//   - It must return an error
-		if !(rty.NumIn() == 1 && rty.NumOut() == 1 && rty.Out(0).Implements(errRefTy)) {
-			panic(`callback must be of type "func (v T) error"`)
-		}
-		callback = true
-		target = reflect.New(rty.In(0)).Interface()
-
-	case reflect.Pointer:
-		// ok
-	default:
-		panic("target value is not a pointer or function")
-	}
-
-	err := r.evaluateExpr(expr, target, opts)
-	if !callback {
-		// error should be handled in the caller
-		return err
-	}
-
-	if err != nil {
-		// If it cannot be represented as a Go value, exit without invoking the callback rather than returning an error.
-		if errors.Is(err, tflint.ErrUnknownValue) ||
-			errors.Is(err, tflint.ErrNullValue) ||
-			errors.Is(err, tflint.ErrSensitive) ||
-			errors.Is(err, tflint.ErrEphemeral) ||
-			errors.Is(err, tflint.ErrUnevaluable) {
-			return nil
-		}
-		return err
-	}
-
-	rerr := rval.Call([]reflect.Value{reflect.ValueOf(target).Elem()})
-	if rerr[0].IsNil() {
-		return nil
-	}
-	return rerr[0].Interface().(error)
+	return runner.EvaluateExpr(expr, target, opts, r.evaluateExpr)
 }
 
 func (r *Runner) evaluateExpr(expr hcl.Expression, target interface{}, opts *tflint.EvaluateExprOption) error {
-	if opts == nil {
-		opts = &tflint.EvaluateExprOption{}
-	}
-
-	var ty cty.Type
-	if opts.WantType != nil {
-		ty = *opts.WantType
-	} else {
-		switch target.(type) {
-		case *string:
-			ty = cty.String
-		case *int:
-			ty = cty.Number
-		case *bool:
-			ty = cty.Bool
-		case *[]string:
-			ty = cty.List(cty.String)
-		case *[]int:
-			ty = cty.List(cty.Number)
-		case *[]bool:
-			ty = cty.List(cty.Bool)
-		case *map[string]string:
-			ty = cty.Map(cty.String)
-		case *map[string]int:
-			ty = cty.Map(cty.Number)
-		case *map[string]bool:
-			ty = cty.Map(cty.Bool)
-		case *cty.Value:
-			ty = cty.DynamicPseudoType
-		default:
-			return fmt.Errorf("unsupported target type: %T", target)
-		}
-	}
+	ty := runner.WantType(target, opts)
 
 	variables := map[string]cty.Value{}
 	for _, variable := range r.variables {
@@ -317,32 +197,7 @@ func (r *Runner) evaluateExpr(expr hcl.Expression, target interface{}, opts *tfl
 		return err
 	}
 
-	if ty == cty.DynamicPseudoType {
-		return gocty.FromCtyValue(val, target)
-	}
-
-	// Returns an error if the value cannot be decoded to a Go value (e.g. unknown, null, marked).
-	// This allows the caller to handle the value by the errors package.
-	err = cty.Walk(val, func(path cty.Path, v cty.Value) (bool, error) {
-		if !v.IsKnown() {
-			return false, tflint.ErrUnknownValue
-		}
-		if v.IsNull() {
-			return false, tflint.ErrNullValue
-		}
-		if v.HasMark(marks.Sensitive) {
-			return false, tflint.ErrSensitive
-		}
-		if v.HasMark(marks.Ephemeral) {
-			return false, tflint.ErrEphemeral
-		}
-		return true, nil
-	})
-	if err != nil {
-		return err
-	}
-
-	return gocty.FromCtyValue(val, target)
+	return runner.DecodeValue(val, ty, expr.Range(), target)
 }
 
 // EmitIssue adds an issue to the runner itself.
@@ -378,14 +233,7 @@ func (r *Runner) Changes() map[string][]byte {
 //
 // Deprecated: Use EvaluateExpr with a function callback. e.g. EvaluateExpr(expr, func (val T) error {}, ...)
 func (r *Runner) EnsureNoError(err error, proc func() error) error {
-	if err == nil {
-		return proc()
-	}
-
-	if errors.Is(err, tflint.ErrUnevaluable) || errors.Is(err, tflint.ErrNullValue) || errors.Is(err, tflint.ErrUnknownValue) || errors.Is(err, tflint.ErrSensitive) {
-		return nil
-	}
-	return err
+	return runner.EnsureNoError(err, proc)
 }
 
 // newLocalRunner initialises a new test runner.

--- a/helper/runner.go
+++ b/helper/runner.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/internal"
 	"github.com/terraform-linters/tflint-plugin-sdk/internal/runner"
@@ -102,50 +101,9 @@ func (r *Runner) GetFiles() (map[string]*hcl.File, error) {
 	return r.files, nil
 }
 
-type nativeWalker struct {
-	walker tflint.ExprWalker
-}
-
-func (w *nativeWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Enter(expr)
-	}
-	return nil
-}
-
-func (w *nativeWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Exit(expr)
-	}
-	return nil
-}
-
 // WalkExpressions traverses expressions in all files by the passed walker.
 func (r *Runner) WalkExpressions(walker tflint.ExprWalker) hcl.Diagnostics {
-	diags := hcl.Diagnostics{}
-	for _, file := range r.files {
-		if body, ok := file.Body.(*hclsyntax.Body); ok {
-			walkDiags := hclsyntax.Walk(body, &nativeWalker{walker: walker})
-			diags = diags.Extend(walkDiags)
-			continue
-		}
-
-		// In JSON syntax, everything can be walked as an attribute.
-		attrs, jsonDiags := file.Body.JustAttributes()
-		if jsonDiags.HasErrors() {
-			diags = diags.Extend(jsonDiags)
-			continue
-		}
-
-		for _, attr := range attrs {
-			enterDiags := walker.Enter(attr.Expr)
-			diags = diags.Extend(enterDiags)
-			exitDiags := walker.Exit(attr.Expr)
-			diags = diags.Extend(exitDiags)
-		}
-	}
-
-	return diags
+	return runner.WalkExpressions(r.files, walker)
 }
 
 // DecodeRuleConfig extracts the rule's configuration into the given value

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -464,6 +464,31 @@ resource "null_resource" "test" {
 			},
 		},
 		{
+			name: "array-based json",
+			files: map[string]string{
+				"main.tf.json": `[
+  {
+    "resource": {
+      "null_resource": {
+        "foo": {}
+      }
+    }
+  },
+  {
+    "variable": {
+      "example": {
+        "type": "string"
+      }
+    }
+  }
+]`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 17}, End: hcl.Pos{Line: 7, Column: 6}},
+				{Start: hcl.Pos{Line: 10, Column: 17}, End: hcl.Pos{Line: 14, Column: 6}},
+			},
+		},
+		{
 			name: "multiple files",
 			files: map[string]string{
 				"main.tf": `

--- a/internal/runner/config.go
+++ b/internal/runner/config.go
@@ -1,0 +1,27 @@
+package runner
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+)
+
+// FetchRuleConfigFunc returns the rule config content matching the schema.
+// A nil content means the rule is not configured.
+type FetchRuleConfigFunc func(schema *hclext.BodySchema) (*hclext.BodyContent, error)
+
+// DecodeRuleConfig infers the schema from ret, fetches the matching rule
+// config content, and decodes it into ret. Missing or empty content leaves
+// ret unchanged.
+func DecodeRuleConfig(ret any, fetch FetchRuleConfigFunc) error {
+	content, err := fetch(hclext.ImpliedBodySchema(ret))
+	if err != nil {
+		return err
+	}
+	if content == nil || content.IsEmpty() {
+		return nil
+	}
+
+	if diags := hclext.DecodeBody(content, nil, ret); diags.HasErrors() {
+		return diags
+	}
+	return nil
+}

--- a/internal/runner/config_test.go
+++ b/internal/runner/config_test.go
@@ -1,0 +1,76 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+)
+
+type ruleConfig struct {
+	Format string `hclext:"format,optional"`
+}
+
+func TestDecodeRuleConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		fetch FetchRuleConfigFunc
+		want  string
+	}{
+		{
+			name: "config is decoded",
+			fetch: func(schema *hclext.BodySchema) (*hclext.BodyContent, error) {
+				if len(schema.Attributes) != 1 || schema.Attributes[0].Name != "format" {
+					t.Fatalf("expected implied schema with a format attribute, but got %#v", schema)
+				}
+
+				file, diags := hclsyntax.ParseConfig([]byte(`format = "snake_case"`), "config.tf", hcl.InitialPos)
+				if diags.HasErrors() {
+					return nil, diags
+				}
+				content, diags := hclext.Content(file.Body, schema)
+				if diags.HasErrors() {
+					return nil, diags
+				}
+				return content, nil
+			},
+			want: "snake_case",
+		},
+		{
+			name: "rule is not configured",
+			fetch: func(schema *hclext.BodySchema) (*hclext.BodyContent, error) {
+				return nil, nil
+			},
+			want: "",
+		},
+		{
+			name: "config is empty",
+			fetch: func(schema *hclext.BodySchema) (*hclext.BodyContent, error) {
+				return &hclext.BodyContent{}, nil
+			},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ret := &ruleConfig{}
+			if err := DecodeRuleConfig(ret, tc.fetch); err != nil {
+				t.Fatal(err)
+			}
+			if ret.Format != tc.want {
+				t.Fatalf("expected %q, but got %q", tc.want, ret.Format)
+			}
+		})
+	}
+}
+
+func TestDecodeRuleConfig_error(t *testing.T) {
+	want := errors.New("unexpected")
+	err := DecodeRuleConfig(&ruleConfig{}, func(schema *hclext.BodySchema) (*hclext.BodyContent, error) {
+		return nil, want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, but got %v", want, err)
+	}
+}

--- a/internal/runner/content.go
+++ b/internal/runner/content.go
@@ -1,0 +1,55 @@
+package runner
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// ModuleContentGetter fetches module content for the content shorthands.
+// Runner implementations satisfy it with their GetModuleContent method.
+type ModuleContentGetter interface {
+	GetModuleContent(schema *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error)
+}
+
+// GetResourceContent gets the contents of resources of the given type based
+// on the schema. This is shorthand of GetModuleContent for resources.
+func GetResourceContent(g ModuleContentGetter, name string, inner *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
+	if opts == nil {
+		opts = &tflint.GetModuleContentOption{}
+	}
+	opts.Hint.ResourceType = name
+
+	return getBlockContent(g, "resource", []string{"type", "name"}, name, inner, opts)
+}
+
+// GetProviderContent gets the contents of providers with the given name based
+// on the schema. This is shorthand of GetModuleContent for providers.
+func GetProviderContent(g ModuleContentGetter, name string, inner *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
+	if opts == nil {
+		opts = &tflint.GetModuleContentOption{}
+	}
+
+	return getBlockContent(g, "provider", []string{"name"}, name, inner, opts)
+}
+
+func getBlockContent(g ModuleContentGetter, blockType string, labelNames []string, name string, inner *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
+	body, err := g.GetModuleContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{Type: blockType, LabelNames: labelNames, Body: inner},
+		},
+	}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	content := &hclext.BodyContent{Blocks: []*hclext.Block{}}
+	for _, block := range body.Blocks {
+		if block.Labels[0] != name {
+			continue
+		}
+
+		content.Blocks = append(content.Blocks, block)
+	}
+
+	return content, nil
+}

--- a/internal/runner/content_test.go
+++ b/internal/runner/content_test.go
@@ -1,0 +1,108 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type fakeGetter struct {
+	schema  *hclext.BodySchema
+	opts    *tflint.GetModuleContentOption
+	content *hclext.BodyContent
+	err     error
+}
+
+func (g *fakeGetter) GetModuleContent(schema *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
+	g.schema = schema
+	g.opts = opts
+	return g.content, g.err
+}
+
+func TestGetResourceContent(t *testing.T) {
+	inner := &hclext.BodySchema{Attributes: []hclext.AttributeSchema{{Name: "instance_type"}}}
+	getter := &fakeGetter{
+		content: &hclext.BodyContent{
+			Blocks: hclext.Blocks{
+				{Type: "resource", Labels: []string{"aws_instance", "foo"}},
+				{Type: "resource", Labels: []string{"aws_s3_bucket", "bar"}},
+				{Type: "resource", Labels: []string{"aws_instance", "baz"}},
+			},
+		},
+	}
+
+	got, err := GetResourceContent(getter, "aws_instance", inner, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &hclext.BodyContent{
+		Blocks: hclext.Blocks{
+			{Type: "resource", Labels: []string{"aws_instance", "foo"}},
+			{Type: "resource", Labels: []string{"aws_instance", "baz"}},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
+
+	wantSchema := &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{Type: "resource", LabelNames: []string{"type", "name"}, Body: inner},
+		},
+	}
+	if diff := cmp.Diff(wantSchema, getter.schema); diff != "" {
+		t.Fatal(diff)
+	}
+
+	if getter.opts.Hint.ResourceType != "aws_instance" {
+		t.Fatalf(`expected hint to be "aws_instance", but got %q`, getter.opts.Hint.ResourceType)
+	}
+}
+
+func TestGetProviderContent(t *testing.T) {
+	inner := &hclext.BodySchema{Attributes: []hclext.AttributeSchema{{Name: "region"}}}
+	getter := &fakeGetter{
+		content: &hclext.BodyContent{
+			Blocks: hclext.Blocks{
+				{Type: "provider", Labels: []string{"aws"}},
+				{Type: "provider", Labels: []string{"google"}},
+			},
+		},
+	}
+
+	got, err := GetProviderContent(getter, "aws", inner, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &hclext.BodyContent{
+		Blocks: hclext.Blocks{
+			{Type: "provider", Labels: []string{"aws"}},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
+
+	wantSchema := &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{Type: "provider", LabelNames: []string{"name"}, Body: inner},
+		},
+	}
+	if diff := cmp.Diff(wantSchema, getter.schema); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestGetResourceContent_error(t *testing.T) {
+	want := errors.New("unexpected")
+	getter := &fakeGetter{err: want}
+
+	if _, err := GetResourceContent(getter, "aws_instance", &hclext.BodySchema{}, nil); !errors.Is(err, want) {
+		t.Fatalf("expected %v, but got %v", want, err)
+	}
+}

--- a/internal/runner/doc.go
+++ b/internal/runner/doc.go
@@ -1,0 +1,10 @@
+// Package runner provides the rule-facing behavior shared by implementations
+// of the tflint.Runner interface: callback dispatch and sentinel error
+// filtering for EvaluateExpr, block filtering for the GetResourceContent and
+// GetProviderContent shorthands, and rule config decoding.
+//
+// Each implementation supplies only what genuinely varies behind the seam:
+// how module content is fetched and how an expression is evaluated into a
+// value. The gRPC client delegates both to the host process; the helper
+// runner serves them from local files.
+package runner

--- a/internal/runner/evaluate.go
+++ b/internal/runner/evaluate.go
@@ -1,0 +1,161 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/logger"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/lang/marks"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+// EvalExprFunc evaluates an expression into the target pointer. The target is
+// always a pointer here; EvaluateExpr resolves callback functions before
+// calling it.
+type EvalExprFunc func(expr hcl.Expression, target any, opts *tflint.EvaluateExprOption) error
+
+var errRefTy = reflect.TypeOf((*error)(nil)).Elem()
+
+// EvaluateExpr dispatches a tflint.Runner.EvaluateExpr target, which must be
+// a pointer or a callback function, to the passed evaluator. Errors that mean
+// the value cannot be represented as a Go value (unknown, null, marked, or
+// unevaluable) skip the callback instead of being returned.
+func EvaluateExpr(expr hcl.Expression, target any, opts *tflint.EvaluateExprOption, eval EvalExprFunc) error {
+	rval := reflect.ValueOf(target)
+	rty := rval.Type()
+
+	var callback bool
+	switch rty.Kind() {
+	case reflect.Func:
+		// Callback must meet the following requirements:
+		//   - It must be a function
+		//   - It must take an argument
+		//   - It must return an error
+		if !(rty.NumIn() == 1 && rty.NumOut() == 1 && rty.Out(0).Implements(errRefTy)) {
+			panic(`callback must be of type "func (v T) error"`)
+		}
+		callback = true
+		target = reflect.New(rty.In(0)).Interface()
+
+	case reflect.Pointer:
+		// ok
+	default:
+		panic("target value is not a pointer or function")
+	}
+
+	err := eval(expr, target, opts)
+	if !callback {
+		// error should be handled in the caller
+		return err
+	}
+
+	if err != nil {
+		// If it cannot be represented as a Go value, exit without invoking the callback rather than returning an error.
+		if errors.Is(err, tflint.ErrUnknownValue) ||
+			errors.Is(err, tflint.ErrNullValue) ||
+			errors.Is(err, tflint.ErrSensitive) ||
+			errors.Is(err, tflint.ErrEphemeral) ||
+			errors.Is(err, tflint.ErrUnevaluable) {
+			return nil
+		}
+		return err
+	}
+
+	rerr := rval.Call([]reflect.Value{reflect.ValueOf(target).Elem()})
+	if rerr[0].IsNil() {
+		return nil
+	}
+	return rerr[0].Interface().(error)
+}
+
+// WantType returns the type the evaluated value should be converted into for
+// the given target pointer. The opts.WantType option takes precedence over
+// inference. Unsupported target types panic, per the documented
+// tflint.Runner.EvaluateExpr contract.
+func WantType(target any, opts *tflint.EvaluateExprOption) cty.Type {
+	if opts != nil && opts.WantType != nil {
+		return *opts.WantType
+	}
+
+	switch target.(type) {
+	case *string:
+		return cty.String
+	case *int:
+		return cty.Number
+	case *bool:
+		return cty.Bool
+	case *[]string:
+		return cty.List(cty.String)
+	case *[]int:
+		return cty.List(cty.Number)
+	case *[]bool:
+		return cty.List(cty.Bool)
+	case *map[string]string:
+		return cty.Map(cty.String)
+	case *map[string]int:
+		return cty.Map(cty.Number)
+	case *map[string]bool:
+		return cty.Map(cty.Bool)
+	case *cty.Value:
+		return cty.DynamicPseudoType
+	default:
+		panic(fmt.Sprintf("unsupported target type: %T", target))
+	}
+}
+
+// DecodeValue decodes an evaluated value into the target pointer. Unless ty
+// is cty.DynamicPseudoType, values that cannot be represented as a Go value
+// return sentinel errors: tflint.ErrUnknownValue, tflint.ErrNullValue,
+// tflint.ErrSensitive, and tflint.ErrEphemeral. The range only appears in
+// debug logs.
+func DecodeValue(val cty.Value, ty cty.Type, rng hcl.Range, target any) error {
+	if ty == cty.DynamicPseudoType {
+		return gocty.FromCtyValue(val, target)
+	}
+
+	// Returns an error if the value cannot be decoded to a Go value (e.g. unknown, null, marked).
+	// This allows the caller to handle the value by the errors package.
+	err := cty.Walk(val, func(path cty.Path, v cty.Value) (bool, error) {
+		if !v.IsKnown() {
+			logger.Debug(fmt.Sprintf("unknown value found in %s", rng))
+			return false, tflint.ErrUnknownValue
+		}
+		if v.IsNull() {
+			logger.Debug(fmt.Sprintf("null value found in %s", rng))
+			return false, tflint.ErrNullValue
+		}
+		if v.HasMark(marks.Sensitive) {
+			logger.Debug(fmt.Sprintf("sensitive value found in %s", rng))
+			return false, tflint.ErrSensitive
+		}
+		if v.HasMark(marks.Ephemeral) {
+			logger.Debug(fmt.Sprintf("ephemeral value found in %s", rng))
+			return false, tflint.ErrEphemeral
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return gocty.FromCtyValue(val, target)
+}
+
+// EnsureNoError runs proc only if err is nil, filtering generally-ignorable
+// evaluation errors. It deliberately does not filter tflint.ErrEphemeral,
+// preserving the historical behavior of the deprecated
+// tflint.Runner.EnsureNoError.
+func EnsureNoError(err error, proc func() error) error {
+	if err == nil {
+		return proc()
+	}
+
+	if errors.Is(err, tflint.ErrUnevaluable) || errors.Is(err, tflint.ErrNullValue) || errors.Is(err, tflint.ErrUnknownValue) || errors.Is(err, tflint.ErrSensitive) {
+		return nil
+	}
+	return err
+}

--- a/internal/runner/evaluate_test.go
+++ b/internal/runner/evaluate_test.go
@@ -1,0 +1,403 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/lang/marks"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEvaluateExpr(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		evalErr    error
+		want       error
+		wantCalled bool
+	}{
+		{
+			name:       "value is passed to the callback",
+			evalErr:    nil,
+			want:       nil,
+			wantCalled: true,
+		},
+		{
+			name:    "unknown value skips the callback",
+			evalErr: tflint.ErrUnknownValue,
+			want:    nil,
+		},
+		{
+			name:    "null value skips the callback",
+			evalErr: tflint.ErrNullValue,
+			want:    nil,
+		},
+		{
+			name:    "sensitive value skips the callback",
+			evalErr: tflint.ErrSensitive,
+			want:    nil,
+		},
+		{
+			name:    "ephemeral value skips the callback",
+			evalErr: tflint.ErrEphemeral,
+			want:    nil,
+		},
+		{
+			name:    "unevaluable value skips the callback",
+			evalErr: tflint.ErrUnevaluable,
+			want:    nil,
+		},
+		{
+			name:    "other errors are returned",
+			evalErr: errors.New("unexpected"),
+			want:    errors.New("unexpected"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eval := func(expr hcl.Expression, target any, opts *tflint.EvaluateExprOption) error {
+				*(target.(*string)) = "value"
+				return tc.evalErr
+			}
+
+			var called bool
+			err := EvaluateExpr(nil, func(val string) error {
+				called = true
+				if val != "value" {
+					t.Fatalf(`expected "value", but got %q`, val)
+				}
+				return nil
+			}, nil, eval)
+
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("expected no error, but got %v", err)
+				}
+			} else if err == nil || err.Error() != tc.want.Error() {
+				t.Fatalf("expected %v, but got %v", tc.want, err)
+			}
+			if called != tc.wantCalled {
+				t.Fatalf("expected callback invocation to be %t, but got %t", tc.wantCalled, called)
+			}
+		})
+	}
+}
+
+func TestEvaluateExpr_pointer(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		evalErr error
+	}{
+		{
+			name:    "value is assigned to the target",
+			evalErr: nil,
+		},
+		{
+			name:    "sentinel errors are returned to the caller",
+			evalErr: tflint.ErrSensitive,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eval := func(expr hcl.Expression, target any, opts *tflint.EvaluateExprOption) error {
+				*(target.(*string)) = "value"
+				return tc.evalErr
+			}
+
+			var got string
+			err := EvaluateExpr(nil, &got, nil, eval)
+			if !errors.Is(err, tc.evalErr) {
+				t.Fatalf("expected %v, but got %v", tc.evalErr, err)
+			}
+			if got != "value" {
+				t.Fatalf(`expected "value", but got %q`, got)
+			}
+		})
+	}
+}
+
+func TestEvaluateExpr_callbackError(t *testing.T) {
+	eval := func(expr hcl.Expression, target any, opts *tflint.EvaluateExprOption) error {
+		return nil
+	}
+
+	want := errors.New("callback error")
+	err := EvaluateExpr(nil, func(val string) error {
+		return want
+	}, nil, eval)
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, but got %v", want, err)
+	}
+}
+
+func TestEvaluateExpr_panics(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		target any
+		want   string
+	}{
+		{
+			name:   "callback without argument",
+			target: func() error { return nil },
+			want:   `callback must be of type "func (v T) error"`,
+		},
+		{
+			name:   "callback without error return",
+			target: func(val string) string { return val },
+			want:   `callback must be of type "func (v T) error"`,
+		},
+		{
+			name:   "target is not a pointer or function",
+			target: "value",
+			want:   "target value is not a pointer or function",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				got := recover()
+				if got != tc.want {
+					t.Fatalf("expected panic %q, but got %v", tc.want, got)
+				}
+			}()
+
+			eval := func(expr hcl.Expression, target any, opts *tflint.EvaluateExprOption) error {
+				return nil
+			}
+			EvaluateExpr(nil, tc.target, nil, eval)
+		})
+	}
+}
+
+func TestWantType(t *testing.T) {
+	wantType := cty.Set(cty.String)
+
+	for _, tc := range []struct {
+		name   string
+		target any
+		opts   *tflint.EvaluateExprOption
+		want   cty.Type
+	}{
+		{
+			name:   "string",
+			target: new(string),
+			want:   cty.String,
+		},
+		{
+			name:   "int",
+			target: new(int),
+			want:   cty.Number,
+		},
+		{
+			name:   "bool",
+			target: new(bool),
+			want:   cty.Bool,
+		},
+		{
+			name:   "string list",
+			target: &[]string{},
+			want:   cty.List(cty.String),
+		},
+		{
+			name:   "int list",
+			target: &[]int{},
+			want:   cty.List(cty.Number),
+		},
+		{
+			name:   "bool list",
+			target: &[]bool{},
+			want:   cty.List(cty.Bool),
+		},
+		{
+			name:   "string map",
+			target: &map[string]string{},
+			want:   cty.Map(cty.String),
+		},
+		{
+			name:   "int map",
+			target: &map[string]int{},
+			want:   cty.Map(cty.Number),
+		},
+		{
+			name:   "bool map",
+			target: &map[string]bool{},
+			want:   cty.Map(cty.Bool),
+		},
+		{
+			name:   "cty value",
+			target: new(cty.Value),
+			want:   cty.DynamicPseudoType,
+		},
+		{
+			name:   "want type option takes precedence",
+			target: new(string),
+			opts:   &tflint.EvaluateExprOption{WantType: &wantType},
+			want:   cty.Set(cty.String),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WantType(tc.target, tc.opts)
+			if !got.Equals(tc.want) {
+				t.Fatalf("expected %s, but got %s", tc.want.FriendlyName(), got.FriendlyName())
+			}
+		})
+	}
+}
+
+func TestWantType_unsupported(t *testing.T) {
+	defer func() {
+		got := recover()
+		if got != "unsupported target type: *float64" {
+			t.Fatalf("expected panic, but got %v", got)
+		}
+	}()
+
+	WantType(new(float64), nil)
+}
+
+func TestDecodeValue(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		val  cty.Value
+		want error
+	}{
+		{
+			name: "known value",
+			val:  cty.StringVal("value"),
+			want: nil,
+		},
+		{
+			name: "unknown value",
+			val:  cty.UnknownVal(cty.String),
+			want: tflint.ErrUnknownValue,
+		},
+		{
+			name: "null value",
+			val:  cty.NullVal(cty.String),
+			want: tflint.ErrNullValue,
+		},
+		{
+			name: "sensitive value",
+			val:  cty.StringVal("value").Mark(marks.Sensitive),
+			want: tflint.ErrSensitive,
+		},
+		{
+			name: "ephemeral value",
+			val:  cty.StringVal("value").Mark(marks.Ephemeral),
+			want: tflint.ErrEphemeral,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			err := DecodeValue(tc.val, cty.String, hcl.Range{}, &got)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("expected %v, but got %v", tc.want, err)
+			}
+			if tc.want == nil && got != "value" {
+				t.Fatalf(`expected "value", but got %q`, got)
+			}
+		})
+	}
+}
+
+func TestDecodeValue_nested(t *testing.T) {
+	var got []string
+	err := DecodeValue(
+		cty.ListVal([]cty.Value{cty.StringVal("value"), cty.UnknownVal(cty.String)}),
+		cty.List(cty.String),
+		hcl.Range{},
+		&got,
+	)
+	if !errors.Is(err, tflint.ErrUnknownValue) {
+		t.Fatalf("expected %v, but got %v", tflint.ErrUnknownValue, err)
+	}
+}
+
+func TestDecodeValue_dynamic(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		val  cty.Value
+	}{
+		{
+			name: "sensitive value",
+			val:  cty.StringVal("value").Mark(marks.Sensitive),
+		},
+		{
+			name: "unknown value",
+			val:  cty.UnknownVal(cty.String),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got cty.Value
+			if err := DecodeValue(tc.val, cty.DynamicPseudoType, hcl.Range{}, &got); err != nil {
+				t.Fatalf("expected no error, but got %v", err)
+			}
+			if !got.RawEquals(tc.val) {
+				t.Fatalf("expected %s, but got %s", tc.val.GoString(), got.GoString())
+			}
+		})
+	}
+}
+
+func TestEnsureNoError(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		err     error
+		want    error
+		wantRun bool
+	}{
+		{
+			name:    "no error",
+			err:     nil,
+			want:    nil,
+			wantRun: true,
+		},
+		{
+			name: "unevaluable error",
+			err:  tflint.ErrUnevaluable,
+			want: nil,
+		},
+		{
+			name: "null value error",
+			err:  tflint.ErrNullValue,
+			want: nil,
+		},
+		{
+			name: "unknown value error",
+			err:  tflint.ErrUnknownValue,
+			want: nil,
+		},
+		{
+			name: "sensitive error",
+			err:  tflint.ErrSensitive,
+			want: nil,
+		},
+		{
+			name: "ephemeral error is not filtered",
+			err:  tflint.ErrEphemeral,
+			want: tflint.ErrEphemeral,
+		},
+		{
+			name: "other error",
+			err:  errors.New("unexpected"),
+			want: errors.New("unexpected"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var run bool
+			err := EnsureNoError(tc.err, func() error {
+				run = true
+				return nil
+			})
+
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("expected no error, but got %v", err)
+				}
+			} else if err == nil || err.Error() != tc.want.Error() {
+				t.Fatalf("expected %v, but got %v", tc.want, err)
+			}
+			if run != tc.wantRun {
+				t.Fatalf("expected proc run to be %t, but got %t", tc.wantRun, run)
+			}
+		})
+	}
+}

--- a/internal/runner/walk.go
+++ b/internal/runner/walk.go
@@ -1,0 +1,129 @@
+package runner
+
+import (
+	stdjson "encoding/json"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// WalkExpressions traverses expressions in the given files by the passed
+// walker. Note that it behaves differently in native HCL syntax and JSON
+// syntax.
+//
+// In the HCL syntax, `var.foo` and `var.bar` in `[var.foo, var.bar]` are
+// also passed to the walker. In other words, it traverses expressions
+// recursively. To avoid redundant checks, the walker should check the kind
+// of expression.
+//
+// In the JSON syntax, only an expression of an attribute seen from the top
+// level of the file is passed. In other words, it doesn't traverse
+// expressions recursively. This is a limitation of JSON syntax.
+func WalkExpressions(files map[string]*hcl.File, walker tflint.ExprWalker) hcl.Diagnostics {
+	diags := hcl.Diagnostics{}
+	for _, file := range files {
+		if body, ok := file.Body.(*hclsyntax.Body); ok {
+			walkDiags := hclsyntax.Walk(body, &nativeWalker{walker: walker})
+			diags = diags.Extend(walkDiags)
+			continue
+		}
+
+		// In JSON syntax, everything can be walked as an attribute.
+		attrs, jsonDiags := getJSONAttributes(file.Body, file.Bytes)
+		if jsonDiags.HasErrors() {
+			diags = diags.Extend(jsonDiags)
+			continue
+		}
+
+		for _, attr := range attrs {
+			enterDiags := walker.Enter(attr.Expr)
+			diags = diags.Extend(enterDiags)
+			exitDiags := walker.Exit(attr.Expr)
+			diags = diags.Extend(exitDiags)
+		}
+	}
+
+	return diags
+}
+
+type nativeWalker struct {
+	walker tflint.ExprWalker
+}
+
+func (w *nativeWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
+	if expr, ok := node.(hcl.Expression); ok {
+		return w.walker.Enter(expr)
+	}
+	return nil
+}
+
+func (w *nativeWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
+	if expr, ok := node.(hcl.Expression); ok {
+		return w.walker.Exit(expr)
+	}
+	return nil
+}
+
+// extractJSONKeys extracts attribute names from JSON bytes using encoding/json.
+// This works for both object-based JSON {"foo": ...} and array-based JSON [{"foo": ...}].
+func extractJSONKeys(bytes []byte) ([]string, error) {
+	// Try to unmarshal as an object first
+	var obj map[string]any
+	if err := stdjson.Unmarshal(bytes, &obj); err == nil {
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+		return keys, nil
+	}
+
+	// Try as an array of objects
+	var arr []map[string]any
+	if err := stdjson.Unmarshal(bytes, &arr); err != nil {
+		return nil, err
+	}
+
+	// Collect all unique keys from all objects in the array
+	keysMap := make(map[string]bool)
+	for _, obj := range arr {
+		for k := range obj {
+			keysMap[k] = true
+		}
+	}
+
+	keys := make([]string, 0, len(keysMap))
+	for k := range keysMap {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+// getJSONAttributes gets all attributes from a JSON body, supporting both object
+// and array-based syntax. For array-based JSON like [{"import": {...}}], it
+// extracts attribute names using encoding/json and builds a schema to extract them.
+func getJSONAttributes(body hcl.Body, bytes []byte) (hcl.Attributes, hcl.Diagnostics) {
+	// First, try JustAttributes (works for object-based JSON)
+	attrs, diags := body.JustAttributes()
+	if !diags.HasErrors() {
+		return attrs, nil
+	}
+
+	// Extract keys using encoding/json
+	keys, err := extractJSONKeys(bytes)
+	if err != nil {
+		return attrs, diags // Return original JustAttributes error
+	}
+
+	// Build a schema with all discovered keys
+	schema := &hcl.BodySchema{
+		Attributes: make([]hcl.AttributeSchema, len(keys)),
+	}
+	for i, key := range keys {
+		schema.Attributes[i] = hcl.AttributeSchema{Name: key}
+	}
+
+	// Use PartialContent to get proper *json.expression objects
+	content, _, partialDiags := body.PartialContent(schema)
+	return content.Attributes, partialDiags
+}

--- a/internal/runner/walk_test.go
+++ b/internal/runner/walk_test.go
@@ -1,0 +1,128 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+func TestWalkExpressions(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		files  map[string]string
+		walked []hcl.Range
+	}{
+		{
+			name: "native syntax walks recursively",
+			files: map[string]string{
+				"resource.tf": `
+resource "null_resource" "test" {
+  key = "foo"
+}`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}},
+			},
+		},
+		{
+			name: "object based json",
+			files: map[string]string{
+				"resource.tf.json": `
+{
+  "resource": {
+    "null_resource": {
+      "test": {
+        "key": "foo"
+      }
+    }
+  }
+}`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 15}, End: hcl.Pos{Line: 9, Column: 4}},
+			},
+		},
+		{
+			name: "array based json",
+			files: map[string]string{
+				"main.tf.json": `[
+  {
+    "resource": {
+      "null_resource": {
+        "foo": {}
+      }
+    }
+  },
+  {
+    "variable": {
+      "example": {
+        "type": "string"
+      }
+    }
+  }
+]`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 17}, End: hcl.Pos{Line: 7, Column: 6}},
+				{Start: hcl.Pos{Line: 10, Column: 17}, End: hcl.Pos{Line: 14, Column: 6}},
+			},
+		},
+		{
+			name: "multiple files",
+			files: map[string]string{
+				"main.tf": `
+locals {
+  key = "foo"
+}`,
+				"main.tf.json": `{"locals": {"key": "bar"}}`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 1, Column: 12}, End: hcl.Pos{Line: 1, Column: 26}, Filename: "main.tf.json"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			files := map[string]*hcl.File{}
+			for name, src := range tc.files {
+				var file *hcl.File
+				var diags hcl.Diagnostics
+				if strings.HasSuffix(name, ".json") {
+					file, diags = hcljson.Parse([]byte(src), name)
+				} else {
+					file, diags = hclsyntax.ParseConfig([]byte(src), name, hcl.InitialPos)
+				}
+				if diags.HasErrors() {
+					t.Fatal(diags)
+				}
+				files[name] = file
+			}
+
+			walked := []hcl.Range{}
+			diags := WalkExpressions(files, tflint.ExprWalkFunc(func(expr hcl.Expression) hcl.Diagnostics {
+				walked = append(walked, expr.Range())
+				return nil
+			}))
+			if diags.HasErrors() {
+				t.Fatal(diags)
+			}
+
+			opts := cmp.Options{
+				cmpopts.IgnoreFields(hcl.Range{}, "Filename"),
+				cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+				cmpopts.SortSlices(func(x, y hcl.Range) bool { return x.String() > y.String() }),
+			}
+			if diff := cmp.Diff(walked, tc.walked, opts); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/plugin/internal/plugin2host/client.go
+++ b/plugin/internal/plugin2host/client.go
@@ -2,7 +2,6 @@ package plugin2host
 
 import (
 	"context"
-	stdjson "encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -138,87 +137,6 @@ func (c *GRPCClient) GetFiles() (map[string]*hcl.File, error) {
 	return files, nil
 }
 
-type nativeWalker struct {
-	walker tflint.ExprWalker
-}
-
-func (w *nativeWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Enter(expr)
-	}
-	return nil
-}
-
-func (w *nativeWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Exit(expr)
-	}
-	return nil
-}
-
-// extractJSONKeys extracts attribute names from JSON bytes using encoding/json.
-// This works for both object-based JSON {"foo": ...} and array-based JSON [{"foo": ...}].
-func extractJSONKeys(bytes []byte) ([]string, error) {
-	// Try to unmarshal as an object first
-	var obj map[string]any
-	if err := stdjson.Unmarshal(bytes, &obj); err == nil {
-		keys := make([]string, 0, len(obj))
-		for k := range obj {
-			keys = append(keys, k)
-		}
-		return keys, nil
-	}
-
-	// Try as an array of objects
-	var arr []map[string]any
-	if err := stdjson.Unmarshal(bytes, &arr); err != nil {
-		return nil, err
-	}
-
-	// Collect all unique keys from all objects in the array
-	keysMap := make(map[string]bool)
-	for _, obj := range arr {
-		for k := range obj {
-			keysMap[k] = true
-		}
-	}
-
-	keys := make([]string, 0, len(keysMap))
-	for k := range keysMap {
-		keys = append(keys, k)
-	}
-	return keys, nil
-}
-
-// getJSONAttributes gets all attributes from a JSON body, supporting both object
-// and array-based syntax. For array-based JSON like [{"import": {...}}], it
-// extracts attribute names using encoding/json and builds a schema to extract them.
-func getJSONAttributes(body hcl.Body, bytes []byte) (hcl.Attributes, hcl.Diagnostics) {
-	// First, try JustAttributes (works for object-based JSON)
-	attrs, diags := body.JustAttributes()
-	if !diags.HasErrors() {
-		return attrs, nil
-	}
-
-	// Extract keys using encoding/json
-	keys, err := extractJSONKeys(bytes)
-	if err != nil {
-		return attrs, diags // Return original JustAttributes error
-	}
-
-	// Build a schema with all discovered keys
-	schema := &hcl.BodySchema{
-		Attributes: make([]hcl.AttributeSchema, len(keys)),
-	}
-	for i, key := range keys {
-		schema.Attributes[i] = hcl.AttributeSchema{Name: key}
-	}
-
-	// Use PartialContent to get proper *json.expression objects
-	content, _, partialDiags := body.PartialContent(schema)
-	return content.Attributes, partialDiags
-}
-
 // WalkExpressions traverses expressions in all files by the passed walker.
 // Note that it behaves differently in native HCL syntax and JSON syntax.
 //
@@ -241,30 +159,7 @@ func (c *GRPCClient) WalkExpressions(walker tflint.ExprWalker) hcl.Diagnostics {
 		}
 	}
 
-	diags := hcl.Diagnostics{}
-	for _, file := range files {
-		if body, ok := file.Body.(*hclsyntax.Body); ok {
-			walkDiags := hclsyntax.Walk(body, &nativeWalker{walker: walker})
-			diags = diags.Extend(walkDiags)
-			continue
-		}
-
-		// In JSON syntax, everything can be walked as an attribute.
-		attrs, jsonDiags := getJSONAttributes(file.Body, file.Bytes)
-		if jsonDiags.HasErrors() {
-			diags = diags.Extend(jsonDiags)
-			continue
-		}
-
-		for _, attr := range attrs {
-			enterDiags := walker.Enter(attr.Expr)
-			diags = diags.Extend(enterDiags)
-			exitDiags := walker.Exit(attr.Expr)
-			diags = diags.Extend(exitDiags)
-		}
-	}
-
-	return diags
+	return runner.WalkExpressions(files, walker)
 }
 
 // DecodeRuleConfig guesses the schema of the rule config from the passed interface and sends the schema to GRPC server.

--- a/plugin/internal/plugin2host/client.go
+++ b/plugin/internal/plugin2host/client.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	stdjson "encoding/json"
 	"errors"
-	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -14,15 +12,12 @@ import (
 	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/internal"
-	"github.com/terraform-linters/tflint-plugin-sdk/logger"
+	"github.com/terraform-linters/tflint-plugin-sdk/internal/runner"
 	"github.com/terraform-linters/tflint-plugin-sdk/plugin/internal/fromproto"
 	"github.com/terraform-linters/tflint-plugin-sdk/plugin/internal/proto"
 	"github.com/terraform-linters/tflint-plugin-sdk/plugin/internal/toproto"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/addrs"
-	"github.com/terraform-linters/tflint-plugin-sdk/terraform/lang/marks"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/gocty"
 	"github.com/zclconf/go-cty/cty/json"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -63,58 +58,13 @@ func (c *GRPCClient) GetModulePath() (addrs.Module, error) {
 // GetResourceContent gets the contents of resources based on the schema.
 // This is shorthand of GetModuleContent for resources
 func (c *GRPCClient) GetResourceContent(name string, inner *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
-	if opts == nil {
-		opts = &tflint.GetModuleContentOption{}
-	}
-	opts.Hint.ResourceType = name
-
-	body, err := c.GetModuleContent(&hclext.BodySchema{
-		Blocks: []hclext.BlockSchema{
-			{Type: "resource", LabelNames: []string{"type", "name"}, Body: inner},
-		},
-	}, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	content := &hclext.BodyContent{Blocks: []*hclext.Block{}}
-	for _, resource := range body.Blocks {
-		if resource.Labels[0] != name {
-			continue
-		}
-
-		content.Blocks = append(content.Blocks, resource)
-	}
-
-	return content, nil
+	return runner.GetResourceContent(c, name, inner, opts)
 }
 
 // GetProviderContent gets the contents of providers based on the schema.
 // This is shorthand of GetModuleContent for providers
 func (c *GRPCClient) GetProviderContent(name string, inner *hclext.BodySchema, opts *tflint.GetModuleContentOption) (*hclext.BodyContent, error) {
-	if opts == nil {
-		opts = &tflint.GetModuleContentOption{}
-	}
-
-	body, err := c.GetModuleContent(&hclext.BodySchema{
-		Blocks: []hclext.BlockSchema{
-			{Type: "provider", LabelNames: []string{"name"}, Body: inner},
-		},
-	}, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	content := &hclext.BodyContent{Blocks: []*hclext.Block{}}
-	for _, provider := range body.Blocks {
-		if provider.Labels[0] != name {
-			continue
-		}
-
-		content.Blocks = append(content.Blocks, provider)
-	}
-
-	return content, nil
+	return runner.GetProviderContent(c, name, inner, opts)
 }
 
 // GetModuleContent gets the contents of the module based on the schema.
@@ -320,80 +270,28 @@ func (c *GRPCClient) WalkExpressions(walker tflint.ExprWalker) hcl.Diagnostics {
 // DecodeRuleConfig guesses the schema of the rule config from the passed interface and sends the schema to GRPC server.
 // Content retrieved based on the schema is decoded into the passed interface.
 func (c *GRPCClient) DecodeRuleConfig(name string, ret interface{}) error {
-	resp, err := c.Client.GetRuleConfigContent(context.Background(), &proto.GetRuleConfigContent_Request{
-		Name:   name,
-		Schema: toproto.BodySchema(hclext.ImpliedBodySchema(ret)),
+	return runner.DecodeRuleConfig(ret, func(schema *hclext.BodySchema) (*hclext.BodyContent, error) {
+		resp, err := c.Client.GetRuleConfigContent(context.Background(), &proto.GetRuleConfigContent_Request{
+			Name:   name,
+			Schema: toproto.BodySchema(schema),
+		})
+		if err != nil {
+			return nil, fromproto.Error(err)
+		}
+
+		content, diags := fromproto.BodyContent(resp.Content)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		return content, nil
 	})
-	if err != nil {
-		return fromproto.Error(err)
-	}
-
-	content, diags := fromproto.BodyContent(resp.Content)
-	if diags.HasErrors() {
-		return diags
-	}
-	if content.IsEmpty() {
-		return nil
-	}
-
-	diags = hclext.DecodeBody(content, nil, ret)
-	if diags.HasErrors() {
-		return diags
-	}
-	return nil
 }
-
-var errRefTy = reflect.TypeOf((*error)(nil)).Elem()
 
 // EvaluateExpr evals the passed expression based on the type.
 // Passing a callback function instead of a value as the target will invoke the callback,
 // passing the evaluated value to the argument.
 func (c *GRPCClient) EvaluateExpr(expr hcl.Expression, target interface{}, opts *tflint.EvaluateExprOption) error {
-	rval := reflect.ValueOf(target)
-	rty := rval.Type()
-
-	var callback bool
-	switch rty.Kind() {
-	case reflect.Func:
-		// Callback must meet the following requirements:
-		//   - It must be a function
-		//   - It must take an argument
-		//   - It must return an error
-		if !(rty.NumIn() == 1 && rty.NumOut() == 1 && rty.Out(0).Implements(errRefTy)) {
-			panic(`callback must be of type "func (v T) error"`)
-		}
-		callback = true
-		target = reflect.New(rty.In(0)).Interface()
-
-	case reflect.Pointer:
-		// ok
-	default:
-		panic("target value is not a pointer or function")
-	}
-
-	err := c.evaluateExpr(expr, target, opts)
-	if !callback {
-		// error should be handled in the caller
-		return err
-	}
-
-	if err != nil {
-		// If it cannot be represented as a Go value, exit without invoking the callback rather than returning an error.
-		if errors.Is(err, tflint.ErrUnknownValue) ||
-			errors.Is(err, tflint.ErrNullValue) ||
-			errors.Is(err, tflint.ErrSensitive) ||
-			errors.Is(err, tflint.ErrEphemeral) ||
-			errors.Is(err, tflint.ErrUnevaluable) {
-			return nil
-		}
-		return err
-	}
-
-	rerr := rval.Call([]reflect.Value{reflect.ValueOf(target).Elem()})
-	if rerr[0].IsNil() {
-		return nil
-	}
-	return rerr[0].Interface().(error)
+	return runner.EvaluateExpr(expr, target, opts, c.evaluateExpr)
 }
 
 func (c *GRPCClient) evaluateExpr(expr hcl.Expression, target interface{}, opts *tflint.EvaluateExprOption) error {
@@ -401,35 +299,7 @@ func (c *GRPCClient) evaluateExpr(expr hcl.Expression, target interface{}, opts 
 		opts = &tflint.EvaluateExprOption{}
 	}
 
-	var ty cty.Type
-	if opts.WantType != nil {
-		ty = *opts.WantType
-	} else {
-		switch target.(type) {
-		case *string:
-			ty = cty.String
-		case *int:
-			ty = cty.Number
-		case *bool:
-			ty = cty.Bool
-		case *[]string:
-			ty = cty.List(cty.String)
-		case *[]int:
-			ty = cty.List(cty.Number)
-		case *[]bool:
-			ty = cty.List(cty.Bool)
-		case *map[string]string:
-			ty = cty.Map(cty.String)
-		case *map[string]int:
-			ty = cty.Map(cty.Number)
-		case *map[string]bool:
-			ty = cty.Map(cty.Bool)
-		case *cty.Value:
-			ty = cty.DynamicPseudoType
-		default:
-			panic(fmt.Sprintf("unsupported target type: %T", target))
-		}
-	}
+	ty := runner.WantType(target, opts)
 	tyby, err := json.MarshalType(ty)
 	if err != nil {
 		return err
@@ -456,36 +326,7 @@ func (c *GRPCClient) evaluateExpr(expr hcl.Expression, target interface{}, opts 
 		return err
 	}
 
-	if ty == cty.DynamicPseudoType {
-		return gocty.FromCtyValue(val, target)
-	}
-
-	// Returns an error if the value cannot be decoded to a Go value (e.g. unknown, null, marked).
-	// This allows the caller to handle the value by the errors package.
-	err = cty.Walk(val, func(path cty.Path, v cty.Value) (bool, error) {
-		if !v.IsKnown() {
-			logger.Debug(fmt.Sprintf("unknown value found in %s", expr.Range()))
-			return false, tflint.ErrUnknownValue
-		}
-		if v.IsNull() {
-			logger.Debug(fmt.Sprintf("null value found in %s", expr.Range()))
-			return false, tflint.ErrNullValue
-		}
-		if v.HasMark(marks.Sensitive) {
-			logger.Debug(fmt.Sprintf("sensitive value found in %s", expr.Range()))
-			return false, tflint.ErrSensitive
-		}
-		if v.HasMark(marks.Ephemeral) {
-			logger.Debug(fmt.Sprintf("ephemeral value found in %s", expr.Range()))
-			return false, tflint.ErrEphemeral
-		}
-		return true, nil
-	})
-	if err != nil {
-		return err
-	}
-
-	return gocty.FromCtyValue(val, target)
+	return runner.DecodeValue(val, ty, expr.Range(), target)
 }
 
 // EmitIssue emits the issue with the passed rule, message, location
@@ -547,12 +388,5 @@ func (c *GRPCClient) ApplyChanges() error {
 //
 // Deprecated: Use errors.Is() instead to determine which errors can be ignored.
 func (*GRPCClient) EnsureNoError(err error, proc func() error) error {
-	if err == nil {
-		return proc()
-	}
-
-	if errors.Is(err, tflint.ErrUnevaluable) || errors.Is(err, tflint.ErrNullValue) || errors.Is(err, tflint.ErrUnknownValue) || errors.Is(err, tflint.ErrSensitive) {
-		return nil
-	}
-	return err
+	return runner.EnsureNoError(err, proc)
 }


### PR DESCRIPTION
Extracts the rule-facing half of `tflint.Runner` into a new `internal/runner` package shared by both implementations. The gRPC client (`plugin/internal/plugin2host`) and the helper test runner each carried near-identical copies of:

- `EvaluateExpr` callback dispatch and sentinel error filtering
- target type inference (the `*string`/`*int`/... switch)
- the post-evaluation unknown/null/sensitive/ephemeral check
- `GetResourceContent` / `GetProviderContent` block filtering
- `DecodeRuleConfig` schema inference and decoding
- `EnsureNoError` filtering

The copies had already drifted once: the helper missed `ErrEphemeral` in its callback filter (fixed in #458) and panicked on marked values where production returned sentinel errors. With one shared implementation, that class of drift can't recur, and each side keeps only what genuinely varies: how module content is fetched and how an expression is evaluated into a value.

## Changes

- New `internal/runner` package with `EvaluateExpr`, `WantType`, `DecodeValue`, `GetResourceContent`, `GetProviderContent`, `DecodeRuleConfig`, and `EnsureNoError`, plus direct unit tests for each (callback dispatch previously had no isolated coverage in either implementation).
- `plugin2host.GRPCClient` and `helper.Runner` delegate to it. Net 356 lines removed from the two implementations.
- No public API changes: `tflint.Runner` is untouched and `go doc ./helper` output is identical.

Three deliberate unifications, all toward documented or production behavior:

- The helper now panics on unsupported target types instead of returning an error, matching the documented `Runner.EvaluateExpr` contract and the production runner.
- The helper now sets `opts.Hint.ResourceType` in `GetResourceContent` like the client; the helper's `GetModuleContent` ignores hints, so this is unobservable.
- The helper's `DecodeRuleConfig` picks up the client's empty-content guard. Equivalent in practice: required attributes already fail earlier in `hclext.Content`.

I deliberately did not unify `WalkExpressions` (the client supports array-based JSON, the helper does not). That's a behavior change for the helper and I'd like to keep this PR a pure refactor; I'll follow up separately.

## Testing

- `internal/runner` has direct table tests: dispatch and panics, sentinel filtering with all five errors, type inference, value decoding including nested and `cty.DynamicPseudoType` targets, content filtering, and rule config decoding.
- The existing `plugin2host` and `helper` suites pass unchanged, which is the behavioral safety net for the rewiring.
