### PR TITLE
Share WalkExpressions between Runner implementations

### DIFF
--- a/helper/runner.go
+++ b/helper/runner.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/internal"
 	"github.com/terraform-linters/tflint-plugin-sdk/internal/runner"
@@ -102,50 +101,9 @@ func (r *Runner) GetFiles() (map[string]*hcl.File, error) {
 	return r.files, nil
 }
 
-type nativeWalker struct {
-	walker tflint.ExprWalker
-}
-
-func (w *nativeWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Enter(expr)
-	}
-	return nil
-}
-
-func (w *nativeWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Exit(expr)
-	}
-	return nil
-}
-
 // WalkExpressions traverses expressions in all files by the passed walker.
 func (r *Runner) WalkExpressions(walker tflint.ExprWalker) hcl.Diagnostics {
-	diags := hcl.Diagnostics{}
-	for _, file := range r.files {
-		if body, ok := file.Body.(*hclsyntax.Body); ok {
-			walkDiags := hclsyntax.Walk(body, &nativeWalker{walker: walker})
-			diags = diags.Extend(walkDiags)
-			continue
-		}
-
-		// In JSON syntax, everything can be walked as an attribute.
-		attrs, jsonDiags := file.Body.JustAttributes()
-		if jsonDiags.HasErrors() {
-			diags = diags.Extend(jsonDiags)
-			continue
-		}
-
-		for _, attr := range attrs {
-			enterDiags := walker.Enter(attr.Expr)
-			diags = diags.Extend(enterDiags)
-			exitDiags := walker.Exit(attr.Expr)
-			diags = diags.Extend(exitDiags)
-		}
-	}
-
-	return diags
+	return runner.WalkExpressions(r.files, walker)
 }
 
 // DecodeRuleConfig extracts the rule's configuration into the given value

--- a/helper/runner_test.go
+++ b/helper/runner_test.go
@@ -464,6 +464,31 @@ resource "null_resource" "test" {
 			},
 		},
 		{
+			name: "array-based json",
+			files: map[string]string{
+				"main.tf.json": `[
+  {
+    "resource": {
+      "null_resource": {
+        "foo": {}
+      }
+    }
+  },
+  {
+    "variable": {
+      "example": {
+        "type": "string"
+      }
+    }
+  }
+]`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 17}, End: hcl.Pos{Line: 7, Column: 6}},
+				{Start: hcl.Pos{Line: 10, Column: 17}, End: hcl.Pos{Line: 14, Column: 6}},
+			},
+		},
+		{
 			name: "multiple files",
 			files: map[string]string{
 				"main.tf": `

--- a/internal/runner/walk.go
+++ b/internal/runner/walk.go
@@ -1,0 +1,129 @@
+package runner
+
+import (
+	stdjson "encoding/json"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// WalkExpressions traverses expressions in the given files by the passed
+// walker. Note that it behaves differently in native HCL syntax and JSON
+// syntax.
+//
+// In the HCL syntax, `var.foo` and `var.bar` in `[var.foo, var.bar]` are
+// also passed to the walker. In other words, it traverses expressions
+// recursively. To avoid redundant checks, the walker should check the kind
+// of expression.
+//
+// In the JSON syntax, only an expression of an attribute seen from the top
+// level of the file is passed. In other words, it doesn't traverse
+// expressions recursively. This is a limitation of JSON syntax.
+func WalkExpressions(files map[string]*hcl.File, walker tflint.ExprWalker) hcl.Diagnostics {
+	diags := hcl.Diagnostics{}
+	for _, file := range files {
+		if body, ok := file.Body.(*hclsyntax.Body); ok {
+			walkDiags := hclsyntax.Walk(body, &nativeWalker{walker: walker})
+			diags = diags.Extend(walkDiags)
+			continue
+		}
+
+		// In JSON syntax, everything can be walked as an attribute.
+		attrs, jsonDiags := getJSONAttributes(file.Body, file.Bytes)
+		if jsonDiags.HasErrors() {
+			diags = diags.Extend(jsonDiags)
+			continue
+		}
+
+		for _, attr := range attrs {
+			enterDiags := walker.Enter(attr.Expr)
+			diags = diags.Extend(enterDiags)
+			exitDiags := walker.Exit(attr.Expr)
+			diags = diags.Extend(exitDiags)
+		}
+	}
+
+	return diags
+}
+
+type nativeWalker struct {
+	walker tflint.ExprWalker
+}
+
+func (w *nativeWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
+	if expr, ok := node.(hcl.Expression); ok {
+		return w.walker.Enter(expr)
+	}
+	return nil
+}
+
+func (w *nativeWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
+	if expr, ok := node.(hcl.Expression); ok {
+		return w.walker.Exit(expr)
+	}
+	return nil
+}
+
+// extractJSONKeys extracts attribute names from JSON bytes using encoding/json.
+// This works for both object-based JSON {"foo": ...} and array-based JSON [{"foo": ...}].
+func extractJSONKeys(bytes []byte) ([]string, error) {
+	// Try to unmarshal as an object first
+	var obj map[string]any
+	if err := stdjson.Unmarshal(bytes, &obj); err == nil {
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+		return keys, nil
+	}
+
+	// Try as an array of objects
+	var arr []map[string]any
+	if err := stdjson.Unmarshal(bytes, &arr); err != nil {
+		return nil, err
+	}
+
+	// Collect all unique keys from all objects in the array
+	keysMap := make(map[string]bool)
+	for _, obj := range arr {
+		for k := range obj {
+			keysMap[k] = true
+		}
+	}
+
+	keys := make([]string, 0, len(keysMap))
+	for k := range keysMap {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+// getJSONAttributes gets all attributes from a JSON body, supporting both object
+// and array-based syntax. For array-based JSON like [{"import": {...}}], it
+// extracts attribute names using encoding/json and builds a schema to extract them.
+func getJSONAttributes(body hcl.Body, bytes []byte) (hcl.Attributes, hcl.Diagnostics) {
+	// First, try JustAttributes (works for object-based JSON)
+	attrs, diags := body.JustAttributes()
+	if !diags.HasErrors() {
+		return attrs, nil
+	}
+
+	// Extract keys using encoding/json
+	keys, err := extractJSONKeys(bytes)
+	if err != nil {
+		return attrs, diags // Return original JustAttributes error
+	}
+
+	// Build a schema with all discovered keys
+	schema := &hcl.BodySchema{
+		Attributes: make([]hcl.AttributeSchema, len(keys)),
+	}
+	for i, key := range keys {
+		schema.Attributes[i] = hcl.AttributeSchema{Name: key}
+	}
+
+	// Use PartialContent to get proper *json.expression objects
+	content, _, partialDiags := body.PartialContent(schema)
+	return content.Attributes, partialDiags
+}

--- a/internal/runner/walk_test.go
+++ b/internal/runner/walk_test.go
@@ -1,0 +1,128 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+func TestWalkExpressions(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		files  map[string]string
+		walked []hcl.Range
+	}{
+		{
+			name: "native syntax walks recursively",
+			files: map[string]string{
+				"resource.tf": `
+resource "null_resource" "test" {
+  key = "foo"
+}`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}},
+			},
+		},
+		{
+			name: "object based json",
+			files: map[string]string{
+				"resource.tf.json": `
+{
+  "resource": {
+    "null_resource": {
+      "test": {
+        "key": "foo"
+      }
+    }
+  }
+}`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 15}, End: hcl.Pos{Line: 9, Column: 4}},
+			},
+		},
+		{
+			name: "array based json",
+			files: map[string]string{
+				"main.tf.json": `[
+  {
+    "resource": {
+      "null_resource": {
+        "foo": {}
+      }
+    }
+  },
+  {
+    "variable": {
+      "example": {
+        "type": "string"
+      }
+    }
+  }
+]`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 17}, End: hcl.Pos{Line: 7, Column: 6}},
+				{Start: hcl.Pos{Line: 10, Column: 17}, End: hcl.Pos{Line: 14, Column: 6}},
+			},
+		},
+		{
+			name: "multiple files",
+			files: map[string]string{
+				"main.tf": `
+locals {
+  key = "foo"
+}`,
+				"main.tf.json": `{"locals": {"key": "bar"}}`,
+			},
+			walked: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 1, Column: 12}, End: hcl.Pos{Line: 1, Column: 26}, Filename: "main.tf.json"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			files := map[string]*hcl.File{}
+			for name, src := range tc.files {
+				var file *hcl.File
+				var diags hcl.Diagnostics
+				if strings.HasSuffix(name, ".json") {
+					file, diags = hcljson.Parse([]byte(src), name)
+				} else {
+					file, diags = hclsyntax.ParseConfig([]byte(src), name, hcl.InitialPos)
+				}
+				if diags.HasErrors() {
+					t.Fatal(diags)
+				}
+				files[name] = file
+			}
+
+			walked := []hcl.Range{}
+			diags := WalkExpressions(files, tflint.ExprWalkFunc(func(expr hcl.Expression) hcl.Diagnostics {
+				walked = append(walked, expr.Range())
+				return nil
+			}))
+			if diags.HasErrors() {
+				t.Fatal(diags)
+			}
+
+			opts := cmp.Options{
+				cmpopts.IgnoreFields(hcl.Range{}, "Filename"),
+				cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+				cmpopts.SortSlices(func(x, y hcl.Range) bool { return x.String() > y.String() }),
+			}
+			if diff := cmp.Diff(walked, tc.walked, opts); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/plugin/internal/plugin2host/client.go
+++ b/plugin/internal/plugin2host/client.go
@@ -2,7 +2,6 @@ package plugin2host
 
 import (
 	"context"
-	stdjson "encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -138,87 +137,6 @@ func (c *GRPCClient) GetFiles() (map[string]*hcl.File, error) {
 	return files, nil
 }
 
-type nativeWalker struct {
-	walker tflint.ExprWalker
-}
-
-func (w *nativeWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Enter(expr)
-	}
-	return nil
-}
-
-func (w *nativeWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
-	if expr, ok := node.(hcl.Expression); ok {
-		return w.walker.Exit(expr)
-	}
-	return nil
-}
-
-// extractJSONKeys extracts attribute names from JSON bytes using encoding/json.
-// This works for both object-based JSON {"foo": ...} and array-based JSON [{"foo": ...}].
-func extractJSONKeys(bytes []byte) ([]string, error) {
-	// Try to unmarshal as an object first
-	var obj map[string]any
-	if err := stdjson.Unmarshal(bytes, &obj); err == nil {
-		keys := make([]string, 0, len(obj))
-		for k := range obj {
-			keys = append(keys, k)
-		}
-		return keys, nil
-	}
-
-	// Try as an array of objects
-	var arr []map[string]any
-	if err := stdjson.Unmarshal(bytes, &arr); err != nil {
-		return nil, err
-	}
-
-	// Collect all unique keys from all objects in the array
-	keysMap := make(map[string]bool)
-	for _, obj := range arr {
-		for k := range obj {
-			keysMap[k] = true
-		}
-	}
-
-	keys := make([]string, 0, len(keysMap))
-	for k := range keysMap {
-		keys = append(keys, k)
-	}
-	return keys, nil
-}
-
-// getJSONAttributes gets all attributes from a JSON body, supporting both object
-// and array-based syntax. For array-based JSON like [{"import": {...}}], it
-// extracts attribute names using encoding/json and builds a schema to extract them.
-func getJSONAttributes(body hcl.Body, bytes []byte) (hcl.Attributes, hcl.Diagnostics) {
-	// First, try JustAttributes (works for object-based JSON)
-	attrs, diags := body.JustAttributes()
-	if !diags.HasErrors() {
-		return attrs, nil
-	}
-
-	// Extract keys using encoding/json
-	keys, err := extractJSONKeys(bytes)
-	if err != nil {
-		return attrs, diags // Return original JustAttributes error
-	}
-
-	// Build a schema with all discovered keys
-	schema := &hcl.BodySchema{
-		Attributes: make([]hcl.AttributeSchema, len(keys)),
-	}
-	for i, key := range keys {
-		schema.Attributes[i] = hcl.AttributeSchema{Name: key}
-	}
-
-	// Use PartialContent to get proper *json.expression objects
-	content, _, partialDiags := body.PartialContent(schema)
-	return content.Attributes, partialDiags
-}
-
 // WalkExpressions traverses expressions in all files by the passed walker.
 // Note that it behaves differently in native HCL syntax and JSON syntax.
 //
@@ -241,30 +159,7 @@ func (c *GRPCClient) WalkExpressions(walker tflint.ExprWalker) hcl.Diagnostics {
 		}
 	}
 
-	diags := hcl.Diagnostics{}
-	for _, file := range files {
-		if body, ok := file.Body.(*hclsyntax.Body); ok {
-			walkDiags := hclsyntax.Walk(body, &nativeWalker{walker: walker})
-			diags = diags.Extend(walkDiags)
-			continue
-		}
-
-		// In JSON syntax, everything can be walked as an attribute.
-		attrs, jsonDiags := getJSONAttributes(file.Body, file.Bytes)
-		if jsonDiags.HasErrors() {
-			diags = diags.Extend(jsonDiags)
-			continue
-		}
-
-		for _, attr := range attrs {
-			enterDiags := walker.Enter(attr.Expr)
-			diags = diags.Extend(enterDiags)
-			exitDiags := walker.Exit(attr.Expr)
-			diags = diags.Extend(exitDiags)
-		}
-	}
-
-	return diags
+	return runner.WalkExpressions(files, walker)
 }
 
 // DecodeRuleConfig guesses the schema of the rule config from the passed interface and sends the schema to GRPC server.


### PR DESCRIPTION
Moves `WalkExpressions` into the shared `internal/runner` package introduced in #460. Stacked on #460.

The gRPC client and the helper test runner each carried their own walking implementation. The helper's lacked the array-based JSON support added to the client in #422, so `WalkExpressions` succeeded in production but returned diagnostics in plugin tests for the same file.

## Changes

- `internal/runner.WalkExpressions(files, walker)` holds the native recursive walk and both JSON paths (`JustAttributes` for object syntax, key extraction plus `PartialContent` for array syntax), with direct tests for each.
- Both implementations delegate to it. The client keeps its `GetFiles()` error-to-diagnostics wrapping.
- The helper gains array-based JSON walking. This is a strictly additive behavior change for plugin test suites: files that previously produced diagnostics now walk. The array-based JSON case from #422 is ported into the helper's `TestWalkExpressions`.

## Testing

- New `internal/runner` table tests cover native recursion, object-based JSON, array-based JSON, and multiple mixed files.
- Existing `TestWalkExpressions` suites in `plugin2host` and `helper` pass unchanged, plus the new helper array-based JSON case.

## References

- #422
